### PR TITLE
docker added

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM ${ARCH}/centos:7
-LABEL version="1"
+LABEL version="2"
 
 RUN yum -y update && \
     yum -y install \
@@ -36,3 +36,6 @@ RUN /root/build-openssl111d.sh
 
 # Install more current gcc for OQS building
 RUN yum -y install centos-release-scl devtoolset-8-gcc* libtool && echo "source /opt/rh/devtoolset-8/enable" >> /root/.bashrc
+
+# Install docker for CCI docker build generation
+RUN cd /root && curl -fsSL https://get.docker.com/ | sh

--- a/centos-7/build-openssl111d.sh
+++ b/centos-7/build-openssl111d.sh
@@ -2,10 +2,9 @@
 set -e
 
 cd /root
-#TODO: See if we can just download the official tarball
-git clone --single-branch https://github.com/openssl/openssl.git
-cd openssl
-git checkout tags/OpenSSL_1_1_1d
+curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz
+tar xzvf OpenSSL_1_1_1d.tar.gz
+cd openssl-OpenSSL_1_1_1d
 ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl no-comp shared
 make
 make install_sw

--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM ${ARCH}/centos:8
-LABEL version="1"
+LABEL version="2"
 
 RUN yum -y update && \
     yum -y install \
@@ -18,3 +18,7 @@ RUN dnf config-manager --set-enabled PowerTools && \
            doxygen-latex \
            doxygen-doxywizard \
            ninja-build
+
+# Install docker for CCI docker image generation
+RUN dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo && dnf install docker-ce --nobest -y
+

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM multiarch/debian-debootstrap:${ARCH}-buster
-LABEL version="1"
+LABEL version="2"
 
 RUN apt-get update -qq
 RUN apt-get upgrade -y
@@ -9,4 +9,4 @@ RUN apt-get install -y gcc
 RUN apt-get install -y cmake ninja-build
 RUN apt-get install -y autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev
 RUN apt-get install -y doxygen graphviz xsltproc
-RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist
+RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io

--- a/ubuntu-bionic/Dockerfile
+++ b/ubuntu-bionic/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM multiarch/ubuntu-core:${ARCH}-bionic
-LABEL version="4"
+LABEL version="5"
 
 RUN apt-get update -qq
 RUN apt-get upgrade -y
@@ -11,4 +11,4 @@ RUN apt-get install -y cmake ninja-build
 RUN apt-get install -y autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev
 RUN apt-get install -y doxygen graphviz xsltproc
 RUN apt-get install -y python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist
-RUN apt-get install -y clang-9
+RUN apt-get install -y clang-9 docker.io


### PR DESCRIPTION
Enabled all (remaining) images to run docker. If OK, please also push resultant images to `openquantumsafe` (dockerhub).

I'll follow up with a PR for an automated CircleCI image-test-build-push config in `oqs-demos` using these images. For the final auto-push to work seamlessly, please [install a CircleCI context](https://circleci.com/docs/2.0/contexts/) `openquantumsafe` with `DOCKER_LOGIN` and `DOCKER_PASSWORD` environment variables correctly set.