### PR TITLE
correcting image target location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,22 +21,22 @@ localCheckout: &localCheckout
         command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
     - run:
         name: Ubuntu-Bionic
-        command: cd ubuntu-bionic && docker build --build-arg ARCH=x86_64 -t ci-ubuntu . && docker tag ci-ubuntu $DOCKER_LOGIN/ci-ubuntu-bionic-x86_64 
+        command: cd ubuntu-bionic && docker build --build-arg ARCH=x86_64 -t ci-ubuntu . && docker tag ci-ubuntu $TARGETNAME/ci-ubuntu-bionic-x86_64 
     - run:
         name: Debian
-        command: cd debian-buster && docker build --build-arg ARCH=amd64 -t ci-debian . && docker tag ci-debian $DOCKER_LOGIN/ci-debian-buster-amd64  
+        command: cd debian-buster && docker build --build-arg ARCH=amd64 -t ci-debian . && docker tag ci-debian $TARGETNAME/ci-debian-buster-amd64  
     - run:
         name: Centos8
-        command: cd centos-8 && docker build --build-arg ARCH=amd64 -t ci-centos8 . && docker tag ci-centos8 $DOCKER_LOGIN/ci-centos-8-amd64
+        command: cd centos-8 && docker build --build-arg ARCH=amd64 -t ci-centos8 . && docker tag ci-centos8 $TARGETNAME/ci-centos-8-amd64
     - run:
         name: Centos7
-        command: cd centos-7 && docker build --build-arg ARCH=amd64 -t ci-centos7 . && docker tag ci-centos7 $DOCKER_LOGIN/ci-centos-7-amd64
+        command: cd centos-7 && docker build --build-arg ARCH=amd64 -t ci-centos7 . && docker tag ci-centos7 $TARGETNAME/ci-centos-7-amd64
     - run:
         name: Alpine
-        command: cd alpine && docker build --build-arg ARCH=amd64 -t ci-alpine . && docker tag ci-alpine $DOCKER_LOGIN/ci-alpine-amd64
+        command: cd alpine && docker build --build-arg ARCH=amd64 -t ci-alpine . && docker tag ci-alpine $TARGETNAME/ci-alpine-amd64
     - run:
         name: Push images
-        command: docker push $DOCKER_LOGIN/ci-ubuntu-bionic-x86_64 && docker push $DOCKER_LOGIN/ci-debian-buster-amd64 && docker push $DOCKER_LOGIN/ci-centos-8-amd64 && docker push $DOCKER_LOGIN/ci-centos-7-amd64 && docker push $DOCKER_LOGIN/ci-alpine-amd64
+        command: docker push $TARGETNAME/ci-ubuntu-bionic-x86_64 && docker push $TARGETNAME/ci-debian-buster-amd64 && docker push $TARGETNAME/ci-centos-8-amd64 && docker push $TARGETNAME/ci-centos-7-amd64 && docker push $TARGETNAME/ci-alpine-amd64
 
 
 jobs:


### PR DESCRIPTION
Apologies @dstebila for cluttering your personal docker hub namespace with ci-images in [the previous run](https://app.circleci.com/pipelines/github/open-quantum-safe/ci-containers/43/workflows/b40cb6e2-3015-4701-b08f-76d8b3dd559c/jobs/601): This PR fixes this.