### PR TITLE
adding clang to Centos-8

### DIFF
--- a/centos-8/Dockerfile
+++ b/centos-8/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM ${ARCH}/centos:8
-LABEL version="3"
+LABEL version="4"
 
 RUN yum -y update && \
     yum -y install \
@@ -8,7 +8,7 @@ RUN yum -y update && \
         gcc \
         cmake \
         autoconf automake git openssl-devel libtool make \
-        python3-pip python3-devel wget && \
+        python3-pip python3-devel wget clang && \
     yum check-update && \
     pip3 install -U nose rednose pytest pytest-xdist psutil
 


### PR DESCRIPTION
clang support not a bad idea anyway. Test run [here](https://app.circleci.com/pipelines/github/baentsch/testing/59/workflows/34c1ba29-32c9-44cd-98d2-33ef1bc3d821/jobs/158)

Reason behind this: New upstream Dilithium self- (and KAT) tests fail only on Centos-8 when building with `-DOQS_PORTABLE_BUILD=OFF` using (Centos-)gcc but pass with the same cmake-setting using `clang`... 
gcc generates code that runs OK with `-DOQS_PORTABLE_BUILD=ON`. Did we ever encounter sth like this before, @xvzcf ? Should I create an issue rather than setting CC=clang in CI for Centos-8 to ensure we get to the bottom of this? 