### PR TITLE
upgrade bionic cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
     description: Building and pushing ARM64 CI image
     docker:
       - image: openquantumsafe/ci-debian-bullseye-amd64
+    resource_class: large
     steps:
       - setup_remote_docker:
           version: 18.09.3

--- a/ubuntu-bionic/Dockerfile
+++ b/ubuntu-bionic/Dockerfile
@@ -36,6 +36,6 @@ RUN apt-get update -qq && \
                        qemu \
                        libc6-dbg
 
-RUN if [ "${ARCH}" != "i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind*; fi
+RUN if [ "${ARCH}" != "i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind* && apt remove -y cmake && cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* ; fi
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"

--- a/ubuntu-bionic/Dockerfile
+++ b/ubuntu-bionic/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update -qq && \
                        qemu \
                        libc6-dbg
 
-RUN if [ "${ARCH}" != "i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind* && apt remove -y cmake && cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* ; fi
+RUN if [ "${ARCH}" != "i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind* ; fi
+
+RUN if [ "${ARCH}" == "i386" ] ; then apt remove -y cmake && cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* ; fi
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"

--- a/ubuntu-bionic/Dockerfile
+++ b/ubuntu-bionic/Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get update -qq && \
                        qemu \
                        libc6-dbg
 
-RUN if [ "${ARCH}" != "i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind* ; fi
+RUN if [ X"${ARCH}" != X"i386" ] ; then cd /tmp && wget https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2 && tar -xf valgrind-3.16.1.tar.bz2 && cd valgrind-3.16.1 && ./autogen.sh && ./configure && make -j 4 && make install && rm -rf /tmp/valgrind* ; fi
 
-RUN if [ "${ARCH}" == "i386" ] ; then apt remove -y cmake && cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* ; fi
+RUN if [ X"${ARCH}" = X"i386" ] ; then apt remove -y cmake && cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* ; fi
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"

--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -40,5 +40,5 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        flex bison \
                        yamllint
 
-RUN cd /root && wget https://doxygen.nl/files/doxygen-1.9.1.src.tar.gz && tar xzvf doxygen-1.9.1.src.tar.gz && cd doxygen-1.9.1 && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make && make install && doxygen --version
+RUN cd /root && wget https://doxygen.nl/files/doxygen-1.9.1.src.tar.gz && tar xzvf doxygen-1.9.1.src.tar.gz && cd doxygen-1.9.1 && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"


### PR DESCRIPTION
As ubuntu is not supporting i386 for focal this PR is to manually insert more current `cmake` into the bionic image. Should allow https://github.com/open-quantum-safe/liboqs/pull/1161 to pass.