### PR TITLE
enable profiling analysis

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM multiarch/ubuntu-core:${ARCH}-focal
-LABEL version="1"
+LABEL version="2"
 
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
@@ -39,6 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        valgrind \
                        flex bison \
                        lsb-release software-properties-common \
+                       lcov \
                        yamllint
 
 RUN cd /root && wget https://doxygen.nl/files/doxygen-1.9.1.src.tar.gz && tar xzvf doxygen-1.9.1.src.tar.gz && cd doxygen-1.9.1 && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version

--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -1,6 +1,7 @@
 ARG ARCH
 FROM multiarch/ubuntu-core:${ARCH}-focal
 LABEL version="2"
+ARG ARCH
 
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
@@ -42,6 +43,6 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        lcov \
                        yamllint
 
-RUN cd /root && wget https://doxygen.nl/files/doxygen-1.9.1.src.tar.gz && tar xzvf doxygen-1.9.1.src.tar.gz && cd doxygen-1.9.1 && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version
+RUN if [ "$ARCH" = "amd64" ] ; then cd / && wget https://doxygen.nl/files/doxygen-1.9.1.src.tar.gz && tar xzvf doxygen-1.9.1.src.tar.gz && cd doxygen-1.9.1 && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
 RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 14 all
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"


### PR DESCRIPTION
Preparing for resolution of https://github.com/open-quantum-safe/liboqs/issues/167.

Problem: ARM64 image times out building (a required recent) doxygen. Vote on proposals / Suggestions welcome how to resolve: 
1) Drop doxygen from ARM64 CI image
2) Utilize larger ARM64 machine (currently: [large](https://github.com/open-quantum-safe/ci-containers/blob/27a2bcfa1d376fd937382c0996d0733f636e5255/.circleci/config.yml#L62) -- see https://circleci.com/product/features/resource-classes/

I'll add code for option "1" without votes to the opposite.