### PR TITLE
update to clang15 and docker command fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
               - run:
                   name: Tag and push image
                   command: |
-                      docker tag docker tag ci-ubuntu-bionic $TARGETNAME/ci-ubuntu-bionic-i386 && docker push $TARGETNAME/ci-ubuntu-bionic-i386
+                      docker tag ci-ubuntu-bionic $TARGETNAME/ci-ubuntu-bionic-i386 && docker push $TARGETNAME/ci-ubuntu-bionic-i386
 
   ubuntu-jammy:
       docker:
@@ -96,7 +96,7 @@ jobs:
             steps:
               - run:
                   name: Tag and push image
-                  command: docker tag ci-ubuntu-jammy $TARGETNAME/ci-ubuntu-jammy && docker push docker push $TARGETNAME/ci-ubuntu-jammy
+                  command: docker tag ci-ubuntu-jammy $TARGETNAME/ci-ubuntu-jammy && docker push $TARGETNAME/ci-ubuntu-jammy
 
 
   arm64:

--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -49,5 +49,5 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     npm -g install ajv ajv-cli
 
 RUN if [ "$ARCH" = "amd64" ] ; then cd / && git clone --depth 1 --branch Release_1_9_2 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
-RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 14 all
+RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 15 all
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"


### PR DESCRIPTION
Fixing failed CI run https://github.com/open-quantum-safe/ci-containers/runs/10530412595:
- clang14 install files no longer available for ubuntu focal ARM image -> update to clang-15
- Fixes to docker tag & push commands