### PR TITLE
python package update for docgen

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 FROM multiarch/ubuntu-core:${ARCH}-focal
-LABEL version="2"
+LABEL version="3"
 ARG ARCH
 
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
@@ -47,7 +47,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        lcov \
                        graphviz \
                        yamllint && \
-    npm -g install ajv ajv-cli
+    npm -g install ajv ajv-cli && \
+    pip3 install tabulate jinja2
 
 RUN if [ "$ARCH" = "amd64" ] ; then cd / && git clone --depth 1 --branch Release_1_9_2 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
 RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 15 all

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:jammy
-LABEL version="1"
+LABEL version="2"
 ARG ARCH
 
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
@@ -7,11 +7,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     echo $TZ > /etc/timezone && \
     apt-get update -qq && \
     apt-get dist-upgrade -y && \
-    apt-get install -y apt-utils wget && \
-    wget https://go.dev/dl/go1.19.3.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.19.3.linux-amd64.tar.gz && \
-    cp /usr/local/go/bin/* /usr/bin && \
-    apt-get install -y autoconf \
+    apt-get install -y apt-utils wget \
+                       autoconf \
                        automake \
                        astyle \
                        clang \
@@ -42,10 +39,12 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        lsb-release software-properties-common \
                        lcov \
                        graphviz \
-                       yamllint
+                       golang \
+                       yamllint && \
+     pip3 install tabulate jinja2
 
 RUN cd / && git clone --depth 1 --branch Release_1_9_2 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version 
 RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 14 all
-ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
+ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-${ARCH}"
 # Activate if we want to test specific OpenSSL3 versions:
 # RUN cd /root && git clone --depth 1 --branch openssl-3.0.7 https://github.com/openssl/openssl.git && cd openssl && LDFLAGS="-Wl,-rpath -Wl,/usr/local/openssl3/lib64"  ./config --prefix=/usr/local/openssl3 && make -j && make install


### PR DESCRIPTION
Enables full src+doc gen via `generate.py` scripts.
Also optimizes `go` installation for ubuntu22.