### PR TITLE
Update cmake in debian buster

### DIFF
--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -25,5 +25,8 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
 #    cp /usr/local/go/bin/* /usr/bin 
 
 # Update cmake
-RUN cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* && cmake --version
+RUN cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake*
+
+ENV PATH=$PATH:/usr/local/bin
+RUN cmake --version
 

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -1,13 +1,13 @@
 ARG ARCH
 FROM multiarch/debian-debootstrap:${ARCH}-buster
-LABEL version="4"
+LABEL version="5"
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update -qq && \
     apt-get upgrade -y && \
     apt-get dist-upgrade -y && \
     apt-get install -y gcc \
-       cmake ninja-build \
+       ninja-build \
        autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
        doxygen  \
        python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io \
@@ -23,4 +23,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
 #    wget https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz && \
 #    tar -C /usr/local -xzf go1.14.3.linux-amd64.tar.gz && \
 #    cp /usr/local/go/bin/* /usr/bin 
+
+# Update cmake
+RUN cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1.tar.gz && tar xzvf cmake-3.22.1.tar.gz && cd cmake-3.22.1 && ./bootstrap && make && make install && rm -rf /tmp/cmake* && cmake --version
 

--- a/debian-buster/Dockerfile
+++ b/debian-buster/Dockerfile
@@ -6,7 +6,7 @@ RUN dpkg --add-architecture arm64 && \
     apt-get update -qq && \
     apt-get upgrade -y && \
     apt-get dist-upgrade -y && \
-    apt-get install -y gcc \
+    apt-get install -y gcc g++ \
        ninja-build \
        autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
        doxygen  \


### PR DESCRIPTION
This would be a quick fix for `armhf` testing: Upgrade `cmake` to a more recent version. Quick fix only as this [OS is pretty dated not receiving security patches any more](https://www.debian.org/releases/buster/) and finally going EOL in 7 months. My strong preference is to upgrade this if we want to keep supporting this. But then again:

Judging from the lack of feedback in https://github.com/orgs/open-quantum-safe/discussions/1583 it doesn't really seem to matter to anyone what platforms we support or in which way.

So I put an alternative fix for [the cmake induced CI failure](https://github.com/open-quantum-safe/liboqs/actions/runs/6756402858/job/18365865360?pr=1601) into https://github.com/open-quantum-safe/liboqs/pull/1601/commits/af759bbf743bb3ecc2e7315cf10c1785e93bcc05 : Just remove `armhf` testing.