### PR TITLE
Install MinGW in Focal for cross-compilation

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -19,6 +19,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        cmake \
                        docker.io \
                        gcc gcc-7 gcc-8\
+                       gcc-mingw-w64\
                        g++ \
                        git \
                        libtool \


### PR DESCRIPTION
To enable CI testing of cross-building for Windows.

See also: open-quantum-safe/liboqs#1696