### PR TITLE
Add curl and sudo to ubuntu-focal

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -47,6 +47,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        lsb-release software-properties-common \
                        lcov \
                        graphviz \
+                       sudo \
+                       curl \
                        yamllint && \
     npm -g install ajv ajv-cli && \
     pip3 install tabulate jinja2


### PR DESCRIPTION
This PR adds `sudo` and `curl` to the Ubuntu focal image which is used in liboqs CI. 

[open-quantum-safe/liboqs#1745](https://github.com/open-quantum-safe/liboqs/pull/1745) adds support for pulling formally verified code from libjade into liboqs. Building libjade requires nix, which in turn requires `curl` and `sudo` currently missing from this image.