### PR TITLE
Update doxygen on ubuntu-focal and ubuntu-jammy

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -53,6 +53,6 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     npm -g install ajv ajv-cli && \
     pip3 install tabulate jinja2
 
-RUN if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x64" ] || [ "$ARCH" = "x86_64" ]; then cd / && git clone --depth 1 --branch Release_1_9_2 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
+RUN if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x64" ] || [ "$ARCH" = "x86_64" ]; then cd / && git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
 RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 15 all
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -43,7 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        yamllint && \
      pip3 install tabulate jinja2
 
-RUN cd / && git clone --depth 1 --branch Release_1_9_2 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version 
+RUN cd / && git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version 
 RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 14 all
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-${ARCH}"
 # Activate if we want to test specific OpenSSL3 versions:


### PR DESCRIPTION
Updates doxygen from release 1.9.2 to release 1.10.0 on images which build doxygen from source (ubuntu-focal and ubuntu-jammy) to catch documentation generation errors in CI (see [openquantumsafe/liboqs#1769](https://github.com/open-quantum-safe/liboqs/pull/1769)).

Fixes #75.