### PR TITLE
update go to 1.22.2

### DIFF
--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -9,8 +9,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     apt-get update -qq && \
     apt-get dist-upgrade -y && \
     apt-get install -y apt-utils wget && \
-    wget https://go.dev/dl/go1.19.3.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.19.3.linux-amd64.tar.gz && \
+    wget https://go.dev/dl/go1.22.2.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz && \
     cp /usr/local/go/bin/* /usr/bin && \
     apt-get install -y autoconf \
                        automake \


### PR DESCRIPTION
Related to https://github.com/open-quantum-safe/boringssl/pull/115

A better way is to create an image for ubuntu noble...