### PR TITLE
Install scan-build and gcc cross-compilation dependencies

### DIFF
--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -14,9 +14,11 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        astyle \
                        clang \
                        clang-format \
+                       clang-tools \
                        cmake \
                        docker.io \
                        gcc \
+                       gcc-mingw-w64 \
                        g++ \
                        git \
                        libtool \


### PR DESCRIPTION
As a follow-up to #85 and to enable https://github.com/open-quantum-safe/liboqs/pull/1909, install additional dependencies to enable `scan-build` and Windows cross-compilation on Ubuntu Noble.