### PR TITLE
Fix build order

### DIFF
--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -1,6 +1,20 @@
 FROM ubuntu:latest
 LABEL version="2"
 
+# actionlint - for GitHub workflow file validation
+# (version pinned to commit hash of v1.7.1)
+FROM golang:1.23 as build
+RUN mkdir /app
+WORKDIR /app
+ENV CGO_ENABLED 0
+RUN git clone https://github.com/rhysd/actionlint.git
+WORKDIR /app/actionlint
+RUN git reset --hard 62dc61a
+RUN go build -o /usr/bin/actionlint ./cmd/actionlint
+# copy built binary from build stage to final image
+FROM ubuntu:latest
+COPY --from=build /usr/local/bin/actionlint /usr/local/bin/actionlint
+
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
@@ -57,20 +71,6 @@ RUN opam init --yes --auto-setup && opam install --confirm-level=unsafe-yes --de
 
 # install ajv for CBOM validation
 RUN npm -g install ajv ajv-cli
-
-# actionlint - for GitHub workflow file validation
-# (version pinned to commit hash of v1.7.1)
-FROM golang:1.23 AS build
-RUN mkdir /app
-WORKDIR /app
-ENV CGO_ENABLED 0
-RUN git clone https://github.com/rhysd/actionlint.git
-WORKDIR /app/actionlint
-RUN git reset --hard 62dc61a
-RUN go build -o /usr/local/bin/actionlint ./cmd/actionlint
-# copy built binary from build stage to final image
-FROM ubuntu:latest
-COPY --from=build /usr/local/bin/actionlint /usr/local/bin/actionlint
 
 # Activate if we want to test specific OpenSSL3 versions:
 # RUN cd /root && git clone --depth 1 --branch openssl-3.0.7 https://github.com/openssl/openssl.git && cd openssl && LDFLAGS="-Wl,-rpath -Wl,/usr/local/openssl3/lib64"  ./config --prefix=/usr/local/openssl3 && make -j && make install

--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:latest as base
 LABEL version="2"
 
 # actionlint - for GitHub workflow file validation
@@ -10,9 +10,10 @@ ENV CGO_ENABLED 0
 RUN git clone https://github.com/rhysd/actionlint.git
 WORKDIR /app/actionlint
 RUN git reset --hard 62dc61a
-RUN go build -o /usr/bin/actionlint ./cmd/actionlint
+RUN go build -o /usr/local/bin/actionlint ./cmd/actionlint
 # copy built binary from build stage to final image
 FROM ubuntu:latest
+WORKDIR /root
 COPY --from=build /usr/local/bin/actionlint /usr/local/bin/actionlint
 
 RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \


### PR DESCRIPTION
If `actionlint` is built as per #87, `git` / `python3` are not available for the rest of the in-progress basic.yml tests.

This re-ordering corrects that.