### PR TITLE
Add curl to ubuntu-latest ci image

### DIFF
--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -34,6 +34,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        clang-format \
                        clang-tools \
                        cmake \
+                       curl \
                        default-jdk-headless \
                        docker.io \
                        gcc \


### PR DESCRIPTION
Add curl to ubuntu-latest ci image since coveralls (our chosen code coverage framework depends on it)

Used in https://github.com/open-quantum-safe/liboqs/pull/2148.