### PR TITLE
Add Python requests to alpine and ubuntu-jammy Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add build-base linux-headers \
             make musl-dev # go
 
 # Unit testing prereqs
-RUN pip3 install -U pytest-xdist nose rednose psutil
+RUN pip3 install -U pytest-xdist nose rednose psutil requests
 
 # No go for the time being:
 ## Configure Go

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -32,6 +32,7 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        python3-pytest-xdist \
                        python3-psutil \
                        python3-pip \
+                       python3-requests \
                        zlib1g-dev \
                        maven \
                        openjdk-11-jdk \


### PR DESCRIPTION
Some jobs in [this CI run](https://github.com/open-quantum-safe/liboqs/actions/runs/18719505368?pr=2303) failed because `openquantumsafe/ci-alpine-amd64:latest` and `openquantumsafe/ci-ubuntu-jammy:latest` do not have the `requests` Python package. The `ubuntu-latest` image does have this package, so the CI tests passed.

This pull request adds the step to install `requests` in the aforementioned Docker images.