### PR TITLE
Automate building Alpine Linux CI image in GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Build image
+      - name: Build ci-alpine-amd64:latest, do not push
         uses: docker/build-push-action@v6
         with:
           push: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,16 @@ jobs:
           build-args: ARCH=${{ matrix.arch }}
           tags: openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-${{ matrix.arch }}
           context: ubuntu-${{ matrix.distro }}
+
+  alpine-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          build-args: ARCH=amd64
+          tags: openquantumsafe/ci-alpine-amd64:latest
+          context: alpine

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,25 @@ on:
     branches: 'main'
 
 jobs:
+  alpine-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        if: github.ref_name == 'main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push ci-alpine-amd64:latest
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          build-args: ARCH=amd64
+          tags: openquantumsafe/ci-alpine-amd64:latest
+          context: alpine
+
   ubuntu-arm64:
     strategy:
       matrix:


### PR DESCRIPTION
Build and push `ci-alpine-amd64:latest` image alongside the Ubuntu-based images for `liboqs` CI platform tests.