### PR TITLE
Add python3-requests to bullseye dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,21 @@ jobs:
           build-args: ARCH=amd64
           tags: openquantumsafe/ci-alpine-amd64:latest
           context: alpine
+
+  debian:
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - armhf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build ci-debian-bullseye-${{ matrix.arch }}:latest, do not push
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          build-args: ARCH=${{ matrix.arch }}
+          tags: openquantumsafe/ci-debian-bullseye-${{ matrix.arch }}:latest
+          context: debian-bullseye

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build ci-debian-bullseye-${{ matrix.arch }}:latest, do not push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,6 +24,30 @@ jobs:
           tags: openquantumsafe/ci-alpine-amd64:latest
           context: alpine
 
+  debian:
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - armhf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        if: github.ref_name == 'main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push ci-debian-bullseye-${{ matrix.arch }}:latest
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          build-args: ARCH=${{ matrix.arch }}
+          tags: openquantumsafe/ci-debian-bullseye-${{ matrix.arch }}:latest
+          context: debian-bullseye
+
   ubuntu-arm64:
     strategy:
       matrix:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Login to Docker Hub
         if: github.ref_name == 'main'
         uses: docker/login-action@v3

--- a/debian-bullseye/Dockerfile
+++ b/debian-bullseye/Dockerfile
@@ -11,7 +11,7 @@ RUN dpkg --add-architecture arm64 && \
        autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
        doxygen  \
        python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io \
-       python3-psutil \
+       python3-psutil python3-requests \
        maven openjdk-11-jdk \
        gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static \
        libssl-dev:arm64


### PR DESCRIPTION
Required due to updates in the test infrastructure (liboqs helpers.py). Missing dependencies causes armhf workflows to fail. Affects weekly tests.