### PR TITLE
ci: notify consumers when a new image is pushed

### DIFF
--- a/.github/scripts/notify-subscribers.sh
+++ b/.github/scripts/notify-subscribers.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Notify subscribed downstream projects that a new version of an OQS CI
+# container image has been published to Docker Hub.
+#
+# For each image whose `LABEL version` changed in the commit that was just
+# built and pushed, this resolves the newly published multi-arch manifest
+# digest and opens a GitHub issue on every repository that subscribes to that
+# image in subscribers.yml.
+#
+# Required environment:
+#   GH_TOKEN      A token with `issues:write` on the subscriber repositories
+#                 (supplied from the NOTIFY_TOKEN secret). If unset, the script
+#                 exits early without notifying.
+#   SOURCE_REPO   owner/repo of this ci-containers repository (github.repository).
+#   SOURCE_SHA    The commit that was built (used for provenance links).
+#
+# Optional (for manual workflow_dispatch runs):
+#   FORCE_IMAGE   Announce this image regardless of the version diff.
+#   FORCE_VERSION Version string to announce (defaults to the Dockerfile label).
+
+set -euo pipefail
+
+ORG=openquantumsafe
+SUBSCRIBERS_FILE=subscribers.yml
+
+# Container directory -> Docker Hub image repo (under openquantumsafe/).
+# Only images that CI actually publishes belong here; keep this in sync with
+# .github/workflows/push.yml.
+declare -A IMAGES=(
+  [ubuntu-focal]=ci-ubuntu-focal
+  [ubuntu-jammy]=ci-ubuntu-jammy
+  [ubuntu-latest]=ci-ubuntu-latest
+  [alpine]=ci-alpine-amd64
+)
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "NOTIFY_TOKEN is not configured; skipping subscriber notifications." >&2
+  exit 0
+fi
+
+# Extract the value of `LABEL version="..."` from a Dockerfile.
+version_of() {
+  grep -iE 'LABEL[[:space:]]+version=' "$1" | head -n1 \
+    | sed -E 's/.*[Vv]ersion="?([^"[:space:]]+)"?.*/\1/'
+}
+
+# Determine which images to announce.
+changed_dirs=()
+if [ -n "${FORCE_IMAGE:-}" ]; then
+  for dir in "${!IMAGES[@]}"; do
+    [ "${IMAGES[$dir]}" = "$FORCE_IMAGE" ] && changed_dirs+=("$dir")
+  done
+  if [ ${#changed_dirs[@]} -eq 0 ]; then
+    echo "FORCE_IMAGE='$FORCE_IMAGE' is not a known published image." >&2
+    exit 1
+  fi
+else
+  for dir in "${!IMAGES[@]}"; do
+    df="$dir/Dockerfile"
+    [ -f "$df" ] || continue
+    # Did this commit change the LABEL version line for this image?
+    if git diff HEAD^ HEAD -- "$df" \
+         | grep -qiE '^\+[[:space:]]*LABEL[[:space:]]+version='; then
+      changed_dirs+=("$dir")
+    fi
+  done
+fi
+
+if [ ${#changed_dirs[@]} -eq 0 ]; then
+  echo "No container version bumps detected in $SOURCE_SHA; nothing to notify."
+  exit 0
+fi
+
+subscriber_count=$(yq e '.subscribers | length' "$SUBSCRIBERS_FILE")
+
+for dir in "${changed_dirs[@]}"; do
+  image="${IMAGES[$dir]}"
+  repo_image="$ORG/$image"
+  version="${FORCE_VERSION:-$(version_of "$dir/Dockerfile")}"
+
+  # Resolve the multi-arch manifest digest that consumers pin as `@sha256:...`.
+  digest=$(docker buildx imagetools inspect "${repo_image}:latest" \
+             --format '{{ .Manifest.Digest }}' 2>/dev/null || true)
+  if [ -z "$digest" ]; then
+    echo "::warning::Could not resolve digest for $repo_image:latest; skipping." >&2
+    continue
+  fi
+
+  short_digest=${digest#sha256:}; short_digest=${short_digest:0:12}
+  echo "Detected new version of $repo_image: version=$version digest=$digest"
+
+  for ((i = 0; i < subscriber_count; i++)); do
+    repo=$(yq e ".subscribers[$i].repo" "$SUBSCRIBERS_FILE")
+    # Skip subscribers that do not watch this image.
+    if ! yq e ".subscribers[$i].images[]" "$SUBSCRIBERS_FILE" \
+           | grep -qx "$image"; then
+      continue
+    fi
+
+    title="New $repo_image version $version available ($short_digest)"
+
+    # Avoid opening a duplicate if this exact version was already announced.
+    existing=$(gh issue list --repo "$repo" --state all \
+                 --search "\"$title\" in:title" --json number --jq 'length' \
+                 2>/dev/null || echo 0)
+    if [ "${existing:-0}" != "0" ]; then
+      echo "  $repo already has an issue for this version; skipping."
+      continue
+    fi
+
+    mentions=$(yq e ".subscribers[$i].mention[]" "$SUBSCRIBERS_FILE" 2>/dev/null \
+                 | sed 's/^/@/' | paste -sd', ' - || true)
+
+    body_file=$(mktemp)
+    {
+      echo "A new version of the OQS CI container image **\`$repo_image\`** has been published to Docker Hub."
+      echo
+      echo "| | |"
+      echo "|---|---|"
+      echo "| Image | \`$repo_image\` |"
+      echo "| New version | \`$version\` |"
+      echo "| Digest | \`$digest\` |"
+      echo "| Published from | [\`$SOURCE_REPO@${SOURCE_SHA:0:12}\`](https://github.com/$SOURCE_REPO/commit/$SOURCE_SHA) |"
+      echo
+      echo "### Pin this image by digest (recommended)"
+      echo
+      echo "Replace any \`:latest\` (or older-digest) reference in your workflows with the immutable digest:"
+      echo
+      echo '```yaml'
+      echo "    container:"
+      echo "      image: $repo_image@$digest"
+      echo '```'
+      echo
+      echo "### Verify"
+      echo
+      echo "- Docker Hub tags: <https://hub.docker.com/r/$repo_image/tags>"
+      echo "- Confirm the digest yourself:"
+      echo
+      echo '```console'
+      echo "\$ docker buildx imagetools inspect ${repo_image}:latest --format '{{ .Manifest.Digest }}'"
+      echo "$digest"
+      echo '```'
+      echo
+      echo "Relying on \`:latest\` (a mutable tag) in CI is a security risk: the image behind it can change without notice. Pinning the digest above guarantees you build against exactly the image published here."
+      echo
+      echo "---"
+      echo "_This issue was opened automatically by [$SOURCE_REPO](https://github.com/$SOURCE_REPO). To change or stop these notifications, edit your entry in [\`subscribers.yml\`](https://github.com/$SOURCE_REPO/blob/main/subscribers.yml)._"
+      if [ -n "$mentions" ]; then echo; echo "cc $mentions"; fi
+    } >"$body_file"
+
+    if url=$(gh issue create --repo "$repo" --title "$title" --body-file "$body_file"); then
+      echo "  Opened issue on $repo: $url"
+    else
+      echo "::warning::Failed to open issue on $repo (check NOTIFY_TOKEN access)." >&2
+    fi
+    rm -f "$body_file"
+  done
+done

--- a/.github/scripts/notify-subscribers.sh
+++ b/.github/scripts/notify-subscribers.sh
@@ -109,8 +109,10 @@ for dir in "${changed_dirs[@]}"; do
       continue
     fi
 
+    # Each mention is a username or an "open-quantum-safe/<team>" team slug;
+    # both are addressed with a leading '@'.
     mentions=$(yq e ".subscribers[$i].mention[]" "$SUBSCRIBERS_FILE" 2>/dev/null \
-                 | sed 's/^/@/' | paste -sd', ' - || true)
+                 | sed 's/^/@/' | paste -sd' ' - || true)
 
     body_file=$(mktemp)
     {

--- a/.github/scripts/validate-subscribers.sh
+++ b/.github/scripts/validate-subscribers.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Validate subscribers.yml so a contributor's PR gets fast, clear feedback.
+# Checks that the file parses, that every entry has a well-formed `repo` and a
+# non-empty `images` list, and that each watched image is one CI publishes.
+
+set -euo pipefail
+
+SUBSCRIBERS_FILE=subscribers.yml
+
+# Keep in sync with .github/scripts/notify-subscribers.sh and push.yml.
+KNOWN_IMAGES=(ci-ubuntu-focal ci-ubuntu-jammy ci-ubuntu-latest ci-alpine-amd64)
+
+fail() { echo "::error file=$SUBSCRIBERS_FILE::$1"; errors=$((errors + 1)); }
+
+errors=0
+
+if ! yq e '.' "$SUBSCRIBERS_FILE" >/dev/null 2>&1; then
+  echo "::error file=$SUBSCRIBERS_FILE::File is not valid YAML."
+  exit 1
+fi
+
+if [ "$(yq e '.subscribers | tag' "$SUBSCRIBERS_FILE")" != "!!seq" ]; then
+  echo "::error file=$SUBSCRIBERS_FILE::Top-level 'subscribers' must be a list."
+  exit 1
+fi
+
+count=$(yq e '.subscribers | length' "$SUBSCRIBERS_FILE")
+if [ "$count" -eq 0 ]; then
+  echo "No subscribers defined; nothing to validate."
+  exit 0
+fi
+
+for ((i = 0; i < count; i++)); do
+  repo=$(yq e ".subscribers[$i].repo // \"\"" "$SUBSCRIBERS_FILE")
+  # Subscriptions are limited to the open-quantum-safe organization (see README).
+  if ! printf '%s' "$repo" | grep -qE '^open-quantum-safe/[A-Za-z0-9_.-]+$'; then
+    fail "subscribers[$i].repo ('$repo') must be an open-quantum-safe repository, e.g. open-quantum-safe/oqs-provider."
+    continue
+  fi
+
+  images_tag=$(yq e ".subscribers[$i].images | tag" "$SUBSCRIBERS_FILE")
+  if [ "$images_tag" != "!!seq" ]; then
+    fail "subscribers[$i] ($repo): 'images' must be a non-empty list."
+    continue
+  fi
+
+  n_images=$(yq e ".subscribers[$i].images | length" "$SUBSCRIBERS_FILE")
+  if [ "$n_images" -eq 0 ]; then
+    fail "subscribers[$i] ($repo): 'images' must not be empty."
+    continue
+  fi
+
+  while IFS= read -r img; do
+    known=0
+    for k in "${KNOWN_IMAGES[@]}"; do
+      [ "$k" = "$img" ] && { known=1; break; }
+    done
+    if [ "$known" -eq 0 ]; then
+      fail "subscribers[$i] ($repo): unknown image '$img'. Known images: ${KNOWN_IMAGES[*]}"
+    fi
+  done < <(yq e ".subscribers[$i].images[]" "$SUBSCRIBERS_FILE")
+done
+
+if [ "$errors" -ne 0 ]; then
+  echo "subscribers.yml validation failed with $errors error(s)."
+  exit 1
+fi
+
+echo "subscribers.yml is valid ($count subscriber(s))."

--- a/.github/scripts/validate-subscribers.sh
+++ b/.github/scripts/validate-subscribers.sh
@@ -40,27 +40,46 @@ for ((i = 0; i < count; i++)); do
   fi
 
   images_tag=$(yq e ".subscribers[$i].images | tag" "$SUBSCRIBERS_FILE")
-  if [ "$images_tag" != "!!seq" ]; then
+  if [ "$images_tag" != "!!seq" ] ||
+     [ "$(yq e ".subscribers[$i].images | length" "$SUBSCRIBERS_FILE")" -eq 0 ]; then
     fail "subscribers[$i] ($repo): 'images' must be a non-empty list."
+  else
+    while IFS= read -r img; do
+      known=0
+      for k in "${KNOWN_IMAGES[@]}"; do
+        [ "$k" = "$img" ] && { known=1; break; }
+      done
+      if [ "$known" -eq 0 ]; then
+        fail "subscribers[$i] ($repo): unknown image '$img'. Known images: ${KNOWN_IMAGES[*]}"
+      fi
+    done < <(yq e ".subscribers[$i].images[]" "$SUBSCRIBERS_FILE")
+  fi
+
+  # 'mention' is optional, but when present each entry must be a bare GitHub
+  # username (a maintainer from the subscribed repository's GOVERNANCE.md) or an
+  # open-quantum-safe team, written 'open-quantum-safe/<team-slug>'. No leading
+  # '@': notify-subscribers.sh adds it.
+  mention_tag=$(yq e ".subscribers[$i].mention | tag" "$SUBSCRIBERS_FILE")
+  if [ "$mention_tag" = "!!null" ]; then
+    continue
+  elif [ "$mention_tag" != "!!seq" ]; then
+    fail "subscribers[$i] ($repo): 'mention' must be a list."
     continue
   fi
 
-  n_images=$(yq e ".subscribers[$i].images | length" "$SUBSCRIBERS_FILE")
-  if [ "$n_images" -eq 0 ]; then
-    fail "subscribers[$i] ($repo): 'images' must not be empty."
-    continue
-  fi
-
-  while IFS= read -r img; do
-    known=0
-    for k in "${KNOWN_IMAGES[@]}"; do
-      [ "$k" = "$img" ] && { known=1; break; }
-    done
-    if [ "$known" -eq 0 ]; then
-      fail "subscribers[$i] ($repo): unknown image '$img'. Known images: ${KNOWN_IMAGES[*]}"
+  while IFS= read -r who; do
+    if ! printf '%s' "$who" |
+         grep -qE '^([A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?|open-quantum-safe/[A-Za-z0-9._-]+)$'; then
+      fail "subscribers[$i] ($repo): mention '$who' must be a GitHub username or an open-quantum-safe team (open-quantum-safe/<team-slug>), without a leading '@'."
     fi
-  done < <(yq e ".subscribers[$i].images[]" "$SUBSCRIBERS_FILE")
+  done < <(yq e ".subscribers[$i].mention[]" "$SUBSCRIBERS_FILE")
 done
+
+# Two entries for the same repository would open duplicate issues.
+dupes=$(yq e '.subscribers[].repo' "$SUBSCRIBERS_FILE" | sort | uniq -d)
+if [ -n "$dupes" ]; then
+  fail "duplicate repo entries: $(printf '%s' "$dupes" | paste -sd' ' -)."
+fi
 
 if [ "$errors" -ne 0 ]; then
   echo "subscribers.yml validation failed with $errors error(s)."

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,48 @@
+name: Notify subscribers of new container versions
+
+# Runs after "Build and push Docker images" finishes on main. If the commit
+# that was built bumped an image's `LABEL version`, subscribers registered in
+# subscribers.yml are notified via a GitHub issue containing the new digest.
+on:
+  workflow_run:
+    workflows: ["Build and push Docker images"]
+    types: [completed]
+  # Manual re-announcement, e.g. to (re)notify a newly added subscriber.
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image to force-notify (e.g. ci-ubuntu-latest)"
+        required: true
+      version:
+        description: "Version to announce (optional; read from the Dockerfile if empty)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    # Only for successful pushes to main, or a manual dispatch.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the built commit
+        uses: actions/checkout@v4
+        with:
+          # For workflow_run, check out the exact commit that was built so the
+          # HEAD^..HEAD diff reflects that push. fetch-depth 0 gives us HEAD^.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Notify subscribers
+        env:
+          GH_TOKEN: ${{ secrets.NOTIFY_TOKEN }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          FORCE_IMAGE: ${{ github.event.inputs.image }}
+          FORCE_VERSION: ${{ github.event.inputs.version }}
+        run: ./.github/scripts/notify-subscribers.sh

--- a/.github/workflows/validate-subscribers.yml
+++ b/.github/workflows/validate-subscribers.yml
@@ -1,0 +1,21 @@
+name: Validate subscribers.yml
+
+# Give contributors fast feedback when they add or edit a subscription.
+on:
+  pull_request:
+    paths:
+      - subscribers.yml
+      - .github/scripts/validate-subscribers.sh
+      - .github/workflows/validate-subscribers.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Validate subscribers.yml
+        run: ./.github/scripts/validate-subscribers.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,56 @@
 
 The **Open Quantum Safe (OQS) project** has the goal of developing and prototyping quantum-resistant cryptography. This repository contains Dockerfiles that establish the environments used for CI testing of the various OQS sub-projects.
 
+The images are published to Docker Hub under [`openquantumsafe`](https://hub.docker.com/u/openquantumsafe), e.g. `openquantumsafe/ci-ubuntu-latest`.
+
+### Consuming these images
+
+`:latest` (and any other version-less tag) is a **mutable** pointer: the image it resolves to can change at any time, so CI pinned to it runs whatever was pushed most recently, without review. We recommend pinning the immutable content digest instead:
+
+```yaml
+jobs:
+  build:
+    container:
+      image: openquantumsafe/ci-ubuntu-latest@sha256:52c9f9c763619c6495b34948c03b613ef1300deba8e615a26ea603d5ab0cfc47
+```
+
+You can read the current digest of any published image with:
+
+```console
+$ docker buildx imagetools inspect openquantumsafe/ci-ubuntu-latest:latest --format '{{ .Manifest.Digest }}'
+```
+
+### Version-change notifications
+
+This repository can open an issue on your project's repository whenever a new version of an image you depend on is published.
+
+**How it works.** Each image's Dockerfile carries a `LABEL version="N"`. When a change to `main` bumps that label and the image is (re)published to Docker Hub, the [`Notify subscribers`](.github/workflows/notify.yml) workflow resolves the newly published multi-arch digest and opens an issue on every subscribed repository. Issues are posted by the [`oqs-bot`](https://github.com/oqs-bot) account and contain the new version, the `@sha256:...` digest to pin, and a link to verify it on Docker Hub.
+
+**Subscribing.** Subscriptions are limited to repositories in the [`open-quantum-safe`](https://github.com/open-quantum-safe) organization. To subscribe, open a pull request adding your project to [`subscribers.yml`](subscribers.yml); once it is merged, you will receive an issue the next time one of your watched images is republished.
+
+```yaml
+subscribers:
+  - repo: open-quantum-safe/oqs-provider   # open-quantum-safe repository that receives the issue
+    images:                                 # images to watch (no "openquantumsafe/" prefix)
+      - ci-ubuntu-latest
+      - ci-ubuntu-jammy
+      - ci-alpine-amd64
+    mention:                                # optional: usernames to @-mention
+      - baentsch
+```
+
+The watchable images are those this repository publishes: `ci-ubuntu-focal`, `ci-ubuntu-jammy`, `ci-ubuntu-latest`, and `ci-alpine-amd64`. A [validation workflow](.github/workflows/validate-subscribers.yml) checks your entry when you open the PR.
+
+**Not part of `open-quantum-safe`?** This notifier is currently limited to the organization's own repositories. If there is demand to notify projects elsewhere, please open an issue or pull request to register your interest.
+
+**For maintainers of this repository.** The default `GITHUB_TOKEN` cannot open issues on other repositories, so notifications run as the `oqs-bot` account, which is a member of the `open-quantum-safe` organization. Store a **fine-grained** personal access token for `oqs-bot` in the `NOTIFY_TOKEN` repository or organization secret, scoped to:
+
+- **Resource owner:** `open-quantum-safe`
+- **Repository access:** the subscriber repositories (or all organization repositories)
+- **Permissions:** _Issues → Read and write_ — nothing else
+
+An organization admin must approve the token, and fine-grained tokens expire (maximum one year), so it needs periodic rotation. If `NOTIFY_TOKEN` is unset the workflow skips notification without failing. Re-announce a specific image manually via the workflow's `workflow_dispatch` trigger.
+
 ### License
 
 This repository is licensed under the MIT License; see [LICENSE.txt](https://github.com/open-quantum-safe/testing/blob/master/LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository can open an issue on your project's repository whenever a new ve
 
 **How it works.** Each image's Dockerfile carries a `LABEL version="N"`. When a change to `main` bumps that label and the image is (re)published to Docker Hub, the [`Notify subscribers`](.github/workflows/notify.yml) workflow resolves the newly published multi-arch digest and opens an issue on every subscribed repository. Issues are posted by the [`oqs-bot`](https://github.com/oqs-bot) account and contain the new version, the `@sha256:...` digest to pin, and a link to verify it on Docker Hub.
 
-**Subscribing.** Subscriptions are limited to repositories in the [`open-quantum-safe`](https://github.com/open-quantum-safe) organization. To subscribe, open a pull request adding your project to [`subscribers.yml`](subscribers.yml); once it is merged, you will receive an issue the next time one of your watched images is republished.
+**Subscribing.** Subscriptions are limited to repositories in the [`open-quantum-safe`](https://github.com/open-quantum-safe) organization. Every non-archived organization repository that consumes these images is already listed in [`subscribers.yml`](subscribers.yml); to add or amend an entry, open a pull request against that file.
 
 ```yaml
 subscribers:
@@ -36,11 +36,13 @@ subscribers:
       - ci-ubuntu-latest
       - ci-ubuntu-jammy
       - ci-alpine-amd64
-    mention:                                # optional: usernames to @-mention
+    mention:                                # optional, see "Who gets mentioned" below
       - baentsch
 ```
 
 The watchable images are those this repository publishes: `ci-ubuntu-focal`, `ci-ubuntu-jammy`, `ci-ubuntu-latest`, and `ci-alpine-amd64`. A [validation workflow](.github/workflows/validate-subscribers.yml) checks your entry when you open the PR.
+
+**Who gets mentioned.** These issues ask a project to review and re-pin a digest, so they must reach whoever is accountable for that decision. A `mention` entry is therefore either a maintainer listed under _Current Maintainers_ in the subscribed repository's own `GOVERNANCE.md`, or, for repositories that do not carry a `GOVERNANCE.md`, an organization team written `open-quantum-safe/<team-slug>`.
 
 **Not part of `open-quantum-safe`?** This notifier is currently limited to the organization's own repositories. If there is demand to notify projects elsewhere, please open an issue or pull request to register your interest.
 

--- a/subscribers.yml
+++ b/subscribers.yml
@@ -1,0 +1,56 @@
+# subscribers.yml
+#
+# Register a project here (by pull request) to be notified whenever a new
+# version of one of the OQS CI container images is published to Docker Hub.
+#
+# When a subscribed image gets a new version, a GitHub issue is opened on your
+# repository containing:
+#   * the new version,
+#   * the image digest (sha256) that consumers should pin, and
+#   * a link to verify it on Docker Hub.
+#
+# The goal is to help you stop depending on the mutable `:latest` tag — which is
+# a security risk, because the image behind it can change without notice — and
+# instead pin an immutable `@sha256:...` digest that you bump deliberately when
+# you receive one of these notifications.
+#
+# ---------------------------------------------------------------------------
+# open-quantum-safe repositories only
+# ---------------------------------------------------------------------------
+# Subscriptions are limited to public repositories in the open-quantum-safe
+# organization. Notifications are delivered by the `oqs-bot` org member using a
+# fine-grained, org-scoped token, so repositories outside the org cannot be
+# notified. To subscribe, add your project to the `subscribers` list below via
+# pull request.
+#
+# Not part of open-quantum-safe but interested in these notifications? This
+# could be extended to other repositories if there is demand — please open a
+# pull request or issue to register your interest.
+#
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+# subscribers:
+#   - repo: <owner>/<repo>        # (required) repository that receives the issue
+#     images:                     # (required) one or more images to watch,
+#       - <image>                 #            named WITHOUT the "openquantumsafe/"
+#       - <image>                 #            prefix (see the list below)
+#     mention:                    # (optional) GitHub usernames to @-mention
+#       - <github-username>       #            in the issue body
+#
+# Watchable images (these are the images CI publishes; keep in sync with
+# .github/workflows/push.yml):
+#   - ci-ubuntu-focal
+#   - ci-ubuntu-jammy
+#   - ci-ubuntu-latest
+#   - ci-alpine-amd64
+# ---------------------------------------------------------------------------
+
+subscribers:
+  - repo: open-quantum-safe/oqs-provider   # must be an open-quantum-safe repository
+    images:
+      - ci-ubuntu-latest
+      - ci-ubuntu-jammy
+      - ci-alpine-amd64
+    mention:
+      - jplomas

--- a/subscribers.yml
+++ b/subscribers.yml
@@ -9,10 +9,10 @@
 #   * the image digest (sha256) that consumers should pin, and
 #   * a link to verify it on Docker Hub.
 #
-# The goal is to help you stop depending on the mutable `:latest` tag — which is
-# a security risk, because the image behind it can change without notice — and
-# instead pin an immutable `@sha256:...` digest that you bump deliberately when
-# you receive one of these notifications.
+# The goal is to help you stop depending on the mutable `:latest` tag (a security
+# risk, because the image behind it can change without notice) and instead pin an
+# immutable `@sha256:...` digest that you bump deliberately when you receive one
+# of these notifications.
 #
 # ---------------------------------------------------------------------------
 # open-quantum-safe repositories only
@@ -24,7 +24,7 @@
 # pull request.
 #
 # Not part of open-quantum-safe but interested in these notifications? This
-# could be extended to other repositories if there is demand — please open a
+# could be extended to other repositories if there is demand.  Please open a
 # pull request or issue to register your interest.
 #
 # ---------------------------------------------------------------------------
@@ -35,8 +35,9 @@
 #     images:                     # (required) one or more images to watch,
 #       - <image>                 #            named WITHOUT the "openquantumsafe/"
 #       - <image>                 #            prefix (see the list below)
-#     mention:                    # (optional) GitHub usernames to @-mention
-#       - <github-username>       #            in the issue body
+#     mention:                    # (optional) who to @-mention in the issue body
+#       - <github-username>       #            see "Who to mention" below
+#       - open-quantum-safe/<team>
 #
 # Watchable images (these are the images CI publishes; keep in sync with
 # .github/workflows/push.yml):
@@ -44,13 +45,60 @@
 #   - ci-ubuntu-jammy
 #   - ci-ubuntu-latest
 #   - ci-alpine-amd64
+#
+# ---------------------------------------------------------------------------
+# Who to mention
+# ---------------------------------------------------------------------------
+# These issues ask a project to review and re-pin an image digest, so they need
+# to reach whoever is accountable for that decision. A `mention` entry must
+# therefore be either:
+#
+#   * a maintainer listed under "Current Maintainers" in the subscribed
+#     repository's own GOVERNANCE.md, or
+#   * an open-quantum-safe team, written `open-quantum-safe/<team-slug>`
+#     (e.g. open-quantum-safe/liboqs-java-maintainers), for repositories that
+#     do not carry a GOVERNANCE.md.
+#
+# Prefer a team where the repository has no GOVERNANCE.md: team membership is
+# maintained in one place and does not go stale here. Individuals who want the
+# notifications but hold neither role should watch this repository instead.
 # ---------------------------------------------------------------------------
 
 subscribers:
-  - repo: open-quantum-safe/oqs-provider   # must be an open-quantum-safe repository
+  # Every non-archived open-quantum-safe repository that consumes these images
+  # on its default branch. Mentions follow the "Who to mention" rule above.
+
+  - repo: open-quantum-safe/liboqs         # must be an open-quantum-safe repository
     images:
       - ci-ubuntu-latest
       - ci-ubuntu-jammy
       - ci-alpine-amd64
-    mention:
-      - jplomas
+    mention:                               # liboqs GOVERNANCE.md maintainers
+      - baentsch
+      - dstebila
+      - xuganyu96
+
+  - repo: open-quantum-safe/oqs-provider
+    images:
+      - ci-ubuntu-latest
+      - ci-ubuntu-jammy
+      - ci-alpine-amd64
+    mention:                               # oqs-provider GOVERNANCE.md maintainers
+      - baentsch
+      - ashman-p
+      - RodriM11
+
+  - repo: open-quantum-safe/liboqs-java
+    images:
+      - ci-ubuntu-latest
+    mention:                               # no GOVERNANCE.md in that repository
+      - open-quantum-safe/liboqs-java-maintainers
+
+  # openssh's ubuntu.yaml still runs on ci-ubuntu-focal-x86_64, which CI stopped
+  # publishing in 2024. ci-ubuntu-focal is its supported successor, so that is
+  # what is watched here.
+  - repo: open-quantum-safe/openssh
+    images:
+      - ci-ubuntu-focal
+    mention:                               # no GOVERNANCE.md in that repository
+      - open-quantum-safe/openssh-release-managers


### PR DESCRIPTION
Following https://github.com/open-quantum-safe/oqs-provider/pull/786 this PR updates the `README.md` to advise use of version pinning over mutable tag pointers.

It also adds an opt-in mechanism that creates an issue on downstream open-quantum-safe projects when a new version of a consumed base CI image is published, so the changes can be reviewed and the digest updated as necessary.

- When a push to `main` bumps an image's `LABEL version` and the image is republished, the `notify.yml` workflow opens an issue (as `oqs-bot`) on every subscribed repo, containing the version, the `@sha256:...` digest to pin, and a link to verify it.
- Projects subscribe by PR to `subscribers.yml`; a validation workflow checks each entry (schema + `open-quantum-safe/` org restriction) on the PR.

This fills a gap Dependabot does not cover (dependabot-core#5819 / #5541, open since 2022).

Required of maintainers/organisation administrators before merge:
- `oqs-bot` is used to create the issues: this is currently a member of the `open-quantum-safe` organisation and has been utilised across the org for automated actions: **please verify this is an acceptable additional use**.
- Ensure a fine-grained PAT for `oqs-bot` (resource owner: open-quantum-safe; repository access: all org repos (or edit this PR if this is to be requested on a per-repo basic); permissions: Issues → Read and write only), and store it as the `NOTIFY_TOKEN` secret.

I’m happy to abandon the secondary notification aspect of this PR, but it seemed like the obvious follow-on.