### PR TITLE
Add pre-build checks and drive CI from an images.yml manifest

### DIFF
--- a/.github/scripts/check-image-versions.sh
+++ b/.github/scripts/check-image-versions.sh
@@ -11,8 +11,8 @@
 #   * an image whose build context changed since BASE_REF has had its version
 #     bumped past the one already released — republishing under a released
 #     version silently changes what consumers get; and
-#   * the label sits in the final build stage, so the published image actually
-#     carries it (a warning: ubuntu-latest currently does not).
+#   * that label sits in the image's final build stage, since only that stage
+#     reaches the published image.
 #
 # BASE_REF is the commit the change is measured against: the pull request base
 # on a PR, the previous commit otherwise. Needs full history (fetch-depth: 0).
@@ -29,12 +29,19 @@ errors=0
 fail() { echo "::error file=$1::$2"; errors=$((errors + 1)); }
 warn() { echo "::warning file=$1::$2"; }
 
-# version_of reads the first `LABEL version="N"` from a Dockerfile on stdin.
-# `sed -n 1s` rather than `head -1` so nothing closes the pipe early and trips
-# pipefail on an otherwise-passing file.
+# version_of prints the `LABEL version` of the *final* build stage of the
+# Dockerfile on stdin, which is the only one the published image carries: each
+# FROM starts a new stage and discards the labels of the one before it.
 version_of() {
-  grep -iE '^[[:space:]]*LABEL[[:space:]]+version=' |
-    sed -nE '1s/.*[Vv]ersion="?([^"[:space:]]+)"?.*/\1/p'
+  awk '
+    tolower($1) == "from" { version = "" }
+    tolower($1) == "label" && tolower($2) ~ /^version=/ {
+      version = $2
+      sub(/^[^=]*=/, "", version)
+      gsub(/"/, "", version)
+    }
+    END { if (version != "") print version }
+  '
 }
 
 is_version() { printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; }
@@ -45,7 +52,9 @@ base=""
 if [ -n "${BASE_REF:-}" ] && git rev-parse -q --verify "${BASE_REF}^{commit}" >/dev/null; then
   base=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || printf '%s' "$BASE_REF")
 else
-  base=$(git rev-parse -q --verify 'HEAD^{commit}' || true)
+  # The parent commit: 'HEAD^' is that, whereas 'HEAD^{commit}' would only peel
+  # HEAD itself to a commit and compare it against itself.
+  base=$(git rev-parse -q --verify 'HEAD^' || true)
 fi
 if [ -z "$base" ]; then
   echo "No base commit available; checking the version format only."
@@ -61,21 +70,12 @@ for dir in "${IMAGES[@]}"; do
 
   version=$(version_of <"$file" || true)
   if [ -z "$version" ]; then
-    fail "$file" "no 'LABEL version=' found; every published image must carry one."
+    fail "$file" "no 'LABEL version=' in the final build stage, so the published image would not carry one. A label in an earlier stage does not reach it."
     continue
   fi
   if ! is_version "$version"; then
     fail "$file" "version '$version' is not a plain incrementing integer, e.g. version=\"4\"."
     continue
-  fi
-
-  # A label in an earlier stage is dropped from the published image, whatever
-  # the Dockerfile appears to say.
-  last_from=$(grep -niE '^[[:space:]]*FROM[[:space:]]' "$file" | tail -n1 | cut -d: -f1)
-  label_line=$(grep -niE '^[[:space:]]*LABEL[[:space:]]+version=' "$file" |
-                 sed -n 1p | cut -d: -f1)
-  if [ "$label_line" -lt "$last_from" ]; then
-    warn "$file" "'LABEL version' on line $label_line belongs to a build stage before the final FROM on line $last_from, so the published image does not carry it."
   fi
 
   [ -n "$base" ] || continue
@@ -85,9 +85,14 @@ for dir in "${IMAGES[@]}"; do
     continue
   fi
 
-  released=$(git show "$base:$file" 2>/dev/null | version_of || true)
-  if [ -z "$released" ]; then
+  if ! git cat-file -e "$base:$file" 2>/dev/null; then
     echo "$dir: version $version, new image."
+    continue
+  fi
+
+  released=$(git show "$base:$file" | version_of || true)
+  if [ -z "$released" ]; then
+    warn "$file" "the released Dockerfile at ${base:0:12} carries no 'LABEL version' in its final stage, so there is nothing to compare against."
     continue
   fi
   if ! is_version "$released"; then

--- a/.github/scripts/check-image-versions.sh
+++ b/.github/scripts/check-image-versions.sh
@@ -1,25 +1,16 @@
 #!/usr/bin/env bash
 #
-# Check the `LABEL version` of every image CI publishes, before anything is
-# built or pushed.
+# Checks each published image's `LABEL version` before anything is built: it
+# exists in the final build stage (the only one the image carries), is a plain
+# integer, and has been bumped past the released one when the build context
+# changed. Republishing under a released version changes `:latest` unannounced.
 #
-# Each push to main republishes `:latest`, so that label is the only signal a
-# consumer has that the image behind the tag has changed. This checks that:
-#
-#   * every image carries a `LABEL version` in the expected format (a plain
-#     incrementing integer, e.g. version="4");
-#   * an image whose build context changed since BASE_REF has had its version
-#     bumped past the one already released — republishing under a released
-#     version silently changes what consumers get; and
-#   * that label sits in the image's final build stage, since only that stage
-#     reaches the published image.
-#
-# BASE_REF is the commit the change is measured against: the pull request base
-# on a PR, the previous commit otherwise. Needs full history (fetch-depth: 0).
+# BASE_REF is what the change is measured against: the PR base, else HEAD^.
+# Needs full history (fetch-depth: 0).
 
 set -euo pipefail
 
-# The image set comes from images.yml, via the one script that reads it.
+# The image set comes from images.yml.
 IMAGES=()
 while IFS= read -r dir; do
   IMAGES+=("$dir")
@@ -29,9 +20,8 @@ errors=0
 fail() { echo "::error file=$1::$2"; errors=$((errors + 1)); }
 warn() { echo "::warning file=$1::$2"; }
 
-# version_of prints the `LABEL version` of the *final* build stage of the
-# Dockerfile on stdin, which is the only one the published image carries: each
-# FROM starts a new stage and discards the labels of the one before it.
+# The `LABEL version` of the final stage of the Dockerfile on stdin: each FROM
+# starts a stage and discards the labels before it.
 version_of() {
   awk '
     tolower($1) == "from" { version = "" }
@@ -46,14 +36,13 @@ version_of() {
 
 is_version() { printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; }
 
-# Compare against the merge base, so commits landed on main since this branch
-# was cut are not mistaken for the branch lowering a version.
+# The merge base, so commits landed on main since the branch was cut are not
+# read as this branch lowering a version.
 base=""
 if [ -n "${BASE_REF:-}" ] && git rev-parse -q --verify "${BASE_REF}^{commit}" >/dev/null; then
   base=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || printf '%s' "$BASE_REF")
 else
-  # The parent commit: 'HEAD^' is that, whereas 'HEAD^{commit}' would only peel
-  # HEAD itself to a commit and compare it against itself.
+  # 'HEAD^' is the parent; 'HEAD^{commit}' would just peel HEAD to itself.
   base=$(git rev-parse -q --verify 'HEAD^' || true)
 fi
 if [ -z "$base" ]; then

--- a/.github/scripts/check-image-versions.sh
+++ b/.github/scripts/check-image-versions.sh
@@ -10,11 +10,16 @@
 
 set -euo pipefail
 
-# The image set comes from images.yml.
+# The image set comes from images.yml. A process substitution swallows the exit
+# status, so an empty result would pass without checking anything.
 IMAGES=()
 while IFS= read -r dir; do
   IMAGES+=("$dir")
 done < <("$(dirname "$0")/list-images.sh" --dirs)
+if [ ${#IMAGES[@]} -eq 0 ]; then
+  echo "::error::list-images.sh returned no images; nothing was checked."
+  exit 1
+fi
 
 errors=0
 fail() { echo "::error file=$1::$2"; errors=$((errors + 1)); }
@@ -46,7 +51,7 @@ else
   base=$(git rev-parse -q --verify 'HEAD^' || true)
 fi
 if [ -z "$base" ]; then
-  echo "No base commit available; checking the version format only."
+  echo "::warning::No base commit available (a shallow checkout?); checking the version format only."
 fi
 
 for dir in "${IMAGES[@]}"; do

--- a/.github/scripts/check-image-versions.sh
+++ b/.github/scripts/check-image-versions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Check the `LABEL version` of every image CI publishes, before anything is
+# built or pushed.
+#
+# Each push to main republishes `:latest`, so that label is the only signal a
+# consumer has that the image behind the tag has changed. This checks that:
+#
+#   * every image carries a `LABEL version` in the expected format (a plain
+#     incrementing integer, e.g. version="4");
+#   * an image whose build context changed since BASE_REF has had its version
+#     bumped past the one already released — republishing under a released
+#     version silently changes what consumers get; and
+#   * the label sits in the final build stage, so the published image actually
+#     carries it (a warning: ubuntu-latest currently does not).
+#
+# BASE_REF is the commit the change is measured against: the pull request base
+# on a PR, the previous commit otherwise. Needs full history (fetch-depth: 0).
+
+set -euo pipefail
+
+# The image set comes from images.yml, via the one script that reads it.
+IMAGES=()
+while IFS= read -r dir; do
+  IMAGES+=("$dir")
+done < <("$(dirname "$0")/list-images.sh" --dirs)
+
+errors=0
+fail() { echo "::error file=$1::$2"; errors=$((errors + 1)); }
+warn() { echo "::warning file=$1::$2"; }
+
+# version_of reads the first `LABEL version="N"` from a Dockerfile on stdin.
+# `sed -n 1s` rather than `head -1` so nothing closes the pipe early and trips
+# pipefail on an otherwise-passing file.
+version_of() {
+  grep -iE '^[[:space:]]*LABEL[[:space:]]+version=' |
+    sed -nE '1s/.*[Vv]ersion="?([^"[:space:]]+)"?.*/\1/p'
+}
+
+is_version() { printf '%s' "$1" | grep -qE '^[1-9][0-9]*$'; }
+
+# Compare against the merge base, so commits landed on main since this branch
+# was cut are not mistaken for the branch lowering a version.
+base=""
+if [ -n "${BASE_REF:-}" ] && git rev-parse -q --verify "${BASE_REF}^{commit}" >/dev/null; then
+  base=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || printf '%s' "$BASE_REF")
+else
+  base=$(git rev-parse -q --verify 'HEAD^{commit}' || true)
+fi
+if [ -z "$base" ]; then
+  echo "No base commit available; checking the version format only."
+fi
+
+for dir in "${IMAGES[@]}"; do
+  file="$dir/Dockerfile"
+
+  if [ ! -f "$file" ]; then
+    fail "$file" "$dir is published by CI but has no Dockerfile."
+    continue
+  fi
+
+  version=$(version_of <"$file" || true)
+  if [ -z "$version" ]; then
+    fail "$file" "no 'LABEL version=' found; every published image must carry one."
+    continue
+  fi
+  if ! is_version "$version"; then
+    fail "$file" "version '$version' is not a plain incrementing integer, e.g. version=\"4\"."
+    continue
+  fi
+
+  # A label in an earlier stage is dropped from the published image, whatever
+  # the Dockerfile appears to say.
+  last_from=$(grep -niE '^[[:space:]]*FROM[[:space:]]' "$file" | tail -n1 | cut -d: -f1)
+  label_line=$(grep -niE '^[[:space:]]*LABEL[[:space:]]+version=' "$file" |
+                 sed -n 1p | cut -d: -f1)
+  if [ "$label_line" -lt "$last_from" ]; then
+    warn "$file" "'LABEL version' on line $label_line belongs to a build stage before the final FROM on line $last_from, so the published image does not carry it."
+  fi
+
+  [ -n "$base" ] || continue
+
+  if git diff --quiet "$base" HEAD -- "$dir"; then
+    echo "$dir: version $version, build context unchanged since ${base:0:12}."
+    continue
+  fi
+
+  released=$(git show "$base:$file" 2>/dev/null | version_of || true)
+  if [ -z "$released" ]; then
+    echo "$dir: version $version, new image."
+    continue
+  fi
+  if ! is_version "$released"; then
+    warn "$file" "released version '$released' at ${base:0:12} is not an integer; skipping the comparison."
+    continue
+  fi
+
+  if [ "$version" -eq "$released" ]; then
+    fail "$file" "$dir has changed but 'LABEL version' is still $version, which is already released. Bump it to $((released + 1))."
+  elif [ "$version" -lt "$released" ]; then
+    fail "$file" "$dir 'LABEL version' is $version, lower than the released $released."
+  else
+    echo "$dir: version $released -> $version."
+  fi
+done
+
+if [ "$errors" -ne 0 ]; then
+  echo "Image version check failed with $errors error(s)."
+  exit 1
+fi
+
+echo "Image versions are consistent."

--- a/.github/scripts/list-images.sh
+++ b/.github/scripts/list-images.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Queries images.yml, the list of images this repository publishes, so that
+# everything needing to know the image set asks one place: the build and publish
+# matrices, the Dockerfile linting and the LABEL version check.
+#
+# Usage:
+#   list-images.sh --dirs        directories holding the images' Dockerfiles
+#   list-images.sh --matrix      Actions matrix: one entry per image and architecture
+#   list-images.sh --multiarch   Actions matrix of the images published as a manifest
+#   list-images.sh --check       check images.yml against the repository layout
+#
+# shellcheck disable=SC2016  # the $names in the jq programs below are jq's, not the shell's
+
+set -euo pipefail
+
+IMAGES_FILE=images.yml
+
+# yq reads the YAML, jq does the work: both are preinstalled on the runners.
+query() { yq -o=json "$IMAGES_FILE" | jq "$@"; }
+
+case "${1:-}" in
+  --dirs)
+    query -r '.images[].dir'
+    ;;
+
+  --matrix)
+    query -c '
+      [ .images[] as $i
+        | ($i.arches | length > 1) as $multiarch
+        | $i.arches[]
+        | { context: $i.dir,
+            image:   $i.image,
+            arch:    .,
+            tag:     (if $multiarch then "latest-\(.)" else "latest" end),
+            runner:  (if . == "arm64" then "ubuntu-24.04-arm" else "ubuntu-latest" end) }
+      ] | {include: .}'
+    ;;
+
+  --multiarch)
+    query -c '
+      [ .images[]
+        | select(.arches | length > 1)
+        | { image: .image, tags: ([.arches[] | "latest-\(.)"] | join(" ")) }
+      ] | {include: .}'
+    ;;
+
+  --check)
+    errors=0
+    while IFS= read -r dir; do
+      [ -f "$dir/Dockerfile" ] || {
+        echo "::error file=$IMAGES_FILE::'$dir' is listed but holds no Dockerfile."
+        errors=$((errors + 1))
+      }
+    done < <(query -r '.images[].dir')
+
+    # A new image directory that nobody added to images.yml is silently never
+    # built, so name the unlisted ones rather than leaving that to be noticed
+    # later. The retired images are expected to be among them.
+    unlisted=""
+    for dir in */; do
+      dir=${dir%/}
+      [ -f "$dir/Dockerfile" ] || continue
+      query -r '.images[].dir' | grep -qx "$dir" || unlisted="$unlisted $dir"
+    done
+    [ -z "$unlisted" ] ||
+      echo "::notice file=$IMAGES_FILE::Not built, having no entry in $IMAGES_FILE:$unlisted"
+
+    [ "$errors" -eq 0 ] || exit 1
+    echo "$IMAGES_FILE matches the repository layout."
+    ;;
+
+  *)
+    sed -n '3,11p' "$0" | sed 's/^# \{0,1\}//' >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/list-images.sh
+++ b/.github/scripts/list-images.sh
@@ -1,14 +1,7 @@
 #!/usr/bin/env bash
 #
-# Queries images.yml, the list of images this repository publishes, so that
-# everything needing to know the image set asks one place: the build and publish
-# matrices, the Dockerfile linting and the LABEL version check.
-#
-# Usage:
-#   list-images.sh --dirs        directories holding the images' Dockerfiles
-#   list-images.sh --matrix      Actions matrix: one entry per image and architecture
-#   list-images.sh --multiarch   Actions matrix of the images published as a manifest
-#   list-images.sh --check       check images.yml against the repository layout
+# Queries images.yml so that everything needing the image set asks one place:
+# the build and publish matrices, the linting and the version check.
 #
 # shellcheck disable=SC2016  # the $names in the jq programs below are jq's, not the shell's
 
@@ -16,8 +9,23 @@ set -euo pipefail
 
 IMAGES_FILE=images.yml
 
-# yq reads the YAML, jq does the work: both are preinstalled on the runners.
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  list-images.sh --dirs        directories holding the images' Dockerfiles
+  list-images.sh --matrix      Actions matrix: one entry per image and architecture
+  list-images.sh --multiarch   Actions matrix of the images published as a manifest
+  list-images.sh --check       check images.yml against the repository layout
+EOF
+  exit 2
+}
+
+# yq reads the YAML, jq does the work; both are preinstalled on the runners.
 query() { yq -o=json "$IMAGES_FILE" | jq "$@"; }
+
+# An empty matrix is skipped without complaint: a green run that built nothing.
+[ "$(query '.images | length')" -gt 0 ] ||
+  { echo "::error file=$IMAGES_FILE::no images are listed." >&2; exit 1; }
 
 case "${1:-}" in
   --dirs)
@@ -33,7 +41,10 @@ case "${1:-}" in
             image:   $i.image,
             arch:    .,
             tag:     (if $multiarch then "latest-\(.)" else "latest" end),
-            runner:  (if . == "arm64" then "ubuntu-24.04-arm" else "ubuntu-latest" end) }
+            # Erroring beats defaulting a new arch onto an x86 runner.
+            runner:  (if . == "arm64" then "ubuntu-24.04-arm"
+                      elif . == "amd64" or . == "x86_64" then "ubuntu-latest"
+                      else error("unknown architecture \(.); add a runner for it in list-images.sh") end) }
       ] | {include: .}'
     ;;
 
@@ -54,9 +65,8 @@ case "${1:-}" in
       }
     done < <(query -r '.images[].dir')
 
-    # A new image directory that nobody added to images.yml is silently never
-    # built, so name the unlisted ones rather than leaving that to be noticed
-    # later. The retired images are expected to be among them.
+    # An unlisted directory is silently never built, so name them. The
+    # retired images are expected to be among them.
     unlisted=""
     for dir in */; do
       dir=${dir%/}
@@ -71,7 +81,6 @@ case "${1:-}" in
     ;;
 
   *)
-    sed -n '3,11p' "$0" | sed 's/^# \{0,1\}//' >&2
-    exit 2
+    usage
     ;;
 esac

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,103 @@
+name: Container image
+
+# Builds one container image, scans it, and optionally publishes it.
+#
+# Both the pull-request build and the publish workflow call this, so the steps
+# live in one place: adding a container means adding a matrix entry there, not
+# copying this block. The scan runs between the build and the push, so an image
+# with a fixable critical vulnerability is never published.
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: Directory holding the image's Dockerfile, e.g. ubuntu-jammy.
+        required: true
+        type: string
+      image:
+        description: Docker Hub repository, without the openquantumsafe/ prefix.
+        required: true
+        type: string
+      tag:
+        description: Tag to build, e.g. latest or latest-x86_64.
+        required: true
+        type: string
+      arch:
+        description: Value passed to the build as the ARCH build-arg.
+        required: true
+        type: string
+      runner:
+        description: Runner to build on; must match the architecture being built.
+        required: true
+        type: string
+      scan:
+        description: Scan the built image for known vulnerabilities.
+        default: true
+        type: boolean
+      push:
+        description: Publish the image to Docker Hub once it has passed the scan.
+        default: false
+        type: boolean
+    secrets:
+      dockerhub_token:
+        description: Docker Hub access token; required when push is true.
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  image:
+    name: ${{ inputs.image }}:${{ inputs.tag }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Loaded into the local daemon rather than pushed, so the scan below sees
+      # exactly the image that would be published.
+      - name: Build ${{ inputs.image }}:${{ inputs.tag }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          push: false
+          load: true
+          context: ${{ inputs.context }}
+          build-args: ARCH=${{ inputs.arch }}
+          tags: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
+
+      - name: Report known vulnerabilities
+        if: inputs.scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          exit-code: 0
+
+      # Only fixable findings block: an unfixed CVE in the upstream base image
+      # is not something a rebuild here can resolve, and is reported above.
+      - name: Fail on fixable critical vulnerabilities
+        if: inputs.scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
+          scanners: vuln
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Login to Docker Hub
+        if: inputs.push
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.dockerhub_token }}
+
+      - name: Push ${{ inputs.image }}:${{ inputs.tag }}
+        if: inputs.push
+        env:
+          # Via the environment rather than expanded into the script, so the
+          # inputs cannot be read as shell.
+          IMAGE: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
+        run: docker push "$IMAGE"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -84,6 +84,11 @@ jobs:
           ignore-unfixed: true
           exit-code: 1
 
+      # So a green run on a fork's main is not read as having published.
+      - name: Skip publishing
+        if: ${{ !inputs.push && github.ref_name == 'main' }}
+        run: echo "::notice::Built and scanned only; this repository holds no Docker Hub credentials."
+
       - name: Login to Docker Hub
         if: inputs.push
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,11 +1,7 @@
 name: Container image
 
-# Builds one container image, scans it, and optionally publishes it.
-#
-# Both the pull-request build and the publish workflow call this, so the steps
-# live in one place: adding a container means adding a matrix entry there, not
-# copying this block. The scan runs between the build and the push, so an image
-# with a fixable critical vulnerability is never published.
+# Builds one image, scans it, optionally publishes it. Called by build.yml and
+# push.yml so the steps live in one place; the scan sits between the two.
 on:
   workflow_call:
     inputs:
@@ -55,8 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # Loaded into the local daemon rather than pushed, so the scan below sees
-      # exactly the image that would be published.
+      # Loaded, not pushed: the scan sees exactly what would be published.
       - name: Build ${{ inputs.image }}:${{ inputs.tag }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -75,14 +70,16 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 0
 
-      # Only fixable findings block: an unfixed CVE in the upstream base image
-      # is not something a rebuild here can resolve, and is reported above.
+      # Narrower than the report above: only distribution packages, the ones a
+      # rebuild can fix. The Go toolchain these images ship carries stdlib CVEs
+      # marked fixed upstream that no distro package delivers.
       - name: Fail on fixable critical vulnerabilities
         if: inputs.scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
           scanners: vuln
+          vuln-type: os # distribution packages only (TRIVY_PKG_TYPES)
           severity: CRITICAL
           ignore-unfixed: true
           exit-code: 1
@@ -96,8 +93,6 @@ jobs:
 
       - name: Push ${{ inputs.image }}:${{ inputs.tag }}
         if: inputs.push
-        env:
-          # Via the environment rather than expanded into the script, so the
-          # inputs cannot be read as shell.
+        env: # via the environment so the inputs cannot be read as shell
           IMAGE: openquantumsafe/${{ inputs.image }}:${{ inputs.tag }}
         run: docker push "$IMAGE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Build Docker images
 
-# Builds and scans every image on a pull request, without publishing anything.
-# Which images exist comes from images.yml, and the steps live in
-# .github/workflows/build-image.yml, so neither is repeated here.
+# Builds and scans every image in images.yml on a pull request, publishing
+# nothing. Steps live in build-image.yml.
 on:
   pull_request:
   push:
@@ -25,8 +24,8 @@ jobs:
 
       - name: Read images.yml
         id: list
-        # Assigned first so that a failure fails the step: inside `echo "x=$(…)"`
-        # the exit status would be echo's, and an empty value would reach fromJSON.
+        # Assigned first: inside `echo "x=$(…)"` a failure would be echo's,
+        # leaving fromJSON an empty string.
         run: |
           images=$(./.github/scripts/list-images.sh --matrix)
           echo "images=$images" >> "$GITHUB_OUTPUT"
@@ -34,6 +33,8 @@ jobs:
   build:
     needs: discover
     strategy:
+      # Report every image's result, not just the first failure's.
+      fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.images) }}
     uses: ./.github/workflows/build-image.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,11 @@ jobs:
 
       - name: Read images.yml
         id: list
-        run: echo "images=$(./.github/scripts/list-images.sh --matrix)" >> "$GITHUB_OUTPUT"
+        # Assigned first so that a failure fails the step: inside `echo "x=$(…)"`
+        # the exit status would be echo's, and an empty value would reach fromJSON.
+        run: |
+          images=$(./.github/scripts/list-images.sh --matrix)
+          echo "images=$images" >> "$GITHUB_OUTPUT"
 
   build:
     needs: discover

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,47 +1,40 @@
 name: Build Docker images
 
+# Builds and scans every image on a pull request, without publishing anything.
+# Which images exist comes from images.yml, and the steps live in
+# .github/workflows/build-image.yml, so neither is repeated here.
 on:
   pull_request:
   push:
     branches-ignore: 'main'
 
-jobs:
-  ubuntu:
-    strategy:
-      matrix:
-        arch:
-          - arm64
-          - x86_64
-        distro:
-          - focal
-          - jammy
-          - latest
-        include:
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-          - arch: x86_64
-            runner: ubuntu-latest
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          build-args: ARCH=${{ matrix.arch }}
-          tags: openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-${{ matrix.arch }}
-          context: ubuntu-${{ matrix.distro }}
+permissions:
+  contents: read
 
-  alpine-amd64:
+jobs:
+  discover:
+    name: Discover images
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.list.outputs.images }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Build ci-alpine-amd64:latest, do not push
-        uses: docker/build-push-action@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          push: false
-          build-args: ARCH=amd64
-          tags: openquantumsafe/ci-alpine-amd64:latest
-          context: alpine
+          persist-credentials: false
+
+      - name: Read images.yml
+        id: list
+        run: echo "images=$(./.github/scripts/list-images.sh --matrix)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: discover
+    strategy:
+      matrix: ${{ fromJSON(needs.discover.outputs.images) }}
+    uses: ./.github/workflows/build-image.yml
+    with:
+      context: ${{ matrix.context }}
+      image: ${{ matrix.image }}
+      tag: ${{ matrix.tag }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,12 +1,7 @@
 name: Pre-build checks
 
-# Cheap checks that run before an image is built or published: the Dockerfiles
-# lint clean, every image's `LABEL version` is well-formed and has been bumped
-# past the released one whenever its build context changes, and the shell and
-# workflow files that drive all of this are themselves linted and audited.
-#
-# Called by "Build and push Docker images", so a failure here stops publication,
-# and run directly on pull requests for fast feedback.
+# Lints the Dockerfiles, checks each image's `LABEL version`, and lints the
+# shell and workflow files. Called by push.yml, so a failure stops publication.
 on:
   pull_request:
   push:
@@ -27,9 +22,8 @@ jobs:
           persist-credentials: false
 
       - name: Run hadolint
-        # Accepted rules are configured in .hadolint.yaml, which hadolint reads
-        # from the working directory. Only the images in images.yml are linted;
-        # the retired directories nothing builds are left alone.
+        # Accepted rules are in .hadolint.yaml. Only images.yml entries are
+        # linted; the retired directories are left alone.
         run: |
           ./.github/scripts/list-images.sh --dirs | sed 's#$#/Dockerfile#' |
             xargs docker run --rm -v "$PWD:/repo:ro" -w /repo \
@@ -78,9 +72,8 @@ jobs:
           persist-credentials: false
 
       - name: Run actionlint
-        # Upstream's own image, rather than the openquantumsafe/ci-ubuntu-latest
-        # one used elsewhere in the organization: this repository builds that
-        # image, and its checks should not depend on it being publishable.
+        # Upstream's image, not openquantumsafe/ci-ubuntu-latest: this
+        # repository builds that one, so its checks must not depend on it.
         run: |
           docker run --rm -v "$PWD:/repo:ro" -w /repo \
             rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,101 @@
+name: Pre-build checks
+
+# Cheap checks that run before an image is built or published: the Dockerfiles
+# lint clean, every image's `LABEL version` is well-formed and has been bumped
+# past the released one whenever its build context changes, and the shell and
+# workflow files that drive all of this are themselves linted and audited.
+#
+# Called by "Build and push Docker images", so a failure here stops publication,
+# and run directly on pull requests for fast feedback.
+on:
+  pull_request:
+  push:
+    branches-ignore: 'main'
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  dockerfiles:
+    name: Lint Dockerfiles with hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run hadolint
+        # Accepted rules are configured in .hadolint.yaml, which hadolint reads
+        # from the working directory. Only the images in images.yml are linted;
+        # the retired directories nothing builds are left alone.
+        run: |
+          ./.github/scripts/list-images.sh --dirs | sed 's#$#/Dockerfile#' |
+            xargs docker run --rm -v "$PWD:/repo:ro" -w /repo \
+              ghcr.io/hadolint/hadolint:v2.14.0-alpine@sha256:7aba693c1442eb31c0b015c129697cb3b6cb7da589d85c7562f9deb435a6657c \
+              hadolint
+
+  images:
+    name: Check images.yml and image versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # the check diffs each build context against the base commit
+          persist-credentials: false
+
+      - name: Check images.yml against the repository layout
+        run: ./.github/scripts/list-images.sh --check
+
+      - name: Check the LABEL version of each published image
+        env:
+          # Empty on a push, where the script falls back to the previous commit.
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/scripts/check-image-versions.sh
+
+  shell:
+    name: Lint shell scripts with shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run shellcheck
+        # Preinstalled on the runner; no action needed.
+        run: git ls-files -z '*.sh' | xargs -0 shellcheck
+
+  workflows:
+    name: Check validity of GitHub workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        # Upstream's own image, rather than the openquantumsafe/ci-ubuntu-latest
+        # one used elsewhere in the organization: this repository builds that
+        # image, and its checks should not depend on it being publishable.
+        run: |
+          docker run --rm -v "$PWD:/repo:ro" -w /repo \
+            rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+            -color
+
+  zizmor:
+    name: Audit GitHub actions security with zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Audit GitHub actions security with zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,81 +1,76 @@
 name: Build and push Docker images
 
+# Publishes every image in images.yml to Docker Hub. Nothing is built until the
+# pre-build checks pass, and nothing is pushed until it has passed the
+# vulnerability scan in .github/workflows/build-image.yml, where the steps live.
 on:
   push:
     branches: 'main'
 
+permissions:
+  contents: read
+
 jobs:
-  alpine-amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Login to Docker Hub
-        if: github.ref_name == 'main'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push ci-alpine-amd64:latest
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          build-args: ARCH=amd64
-          tags: openquantumsafe/ci-alpine-amd64:latest
-          context: alpine
+  checks:
+    uses: ./.github/workflows/checks.yml
 
-  ubuntu-arm64:
-    strategy:
-      matrix:
-        distro:
-          - focal
-          - jammy
-          - latest
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push arm64 tag
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          build-args: ARCH=arm64
-          tags: openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-arm64
-          context: ubuntu-${{ matrix.distro }}
-
-  ubuntu-x86_64:
-    needs: ubuntu-arm64
-    strategy:
-      matrix:
-        distro:
-          - focal
-          - jammy
-          - latest
+  discover:
+    name: Discover images
+    needs: checks
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+      multiarch: ${{ steps.list.outputs.multiarch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Login to Docker Hub
-        if: github.ref_name == 'main'
-        uses: docker/login-action@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push x86_64 tag
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          build-args: ARCH=x86_64
-          tags: openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-x86_64
-          context: ubuntu-${{ matrix.distro }}
-      - name: Create multiarch image
+          persist-credentials: false
+
+      - name: Read images.yml
+        id: list
         run: |
-          docker manifest create openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest \
-            --amend openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-x86_64 \
-            --amend openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest-arm64 \
-            && docker manifest push openquantumsafe/ci-ubuntu-${{ matrix.distro }}:latest
+          {
+            echo "images=$(./.github/scripts/list-images.sh --matrix)"
+            echo "multiarch=$(./.github/scripts/list-images.sh --multiarch)"
+          } >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: discover
+    strategy:
+      matrix: ${{ fromJSON(needs.discover.outputs.images) }}
+    uses: ./.github/workflows/build-image.yml
+    with:
+      context: ${{ matrix.context }}
+      image: ${{ matrix.image }}
+      tag: ${{ matrix.tag }}
+      arch: ${{ matrix.arch }}
+      runner: ${{ matrix.runner }}
+      push: true
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # The per-architecture tags are published above; for an image built for more
+  # than one architecture, :latest is the manifest spanning them.
+  multiarch:
+    name: Manifest for ${{ matrix.image }}
+    needs: [discover, publish]
+    strategy:
+      matrix: ${{ fromJSON(needs.discover.outputs.multiarch) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish the multi-architecture manifest
+        env:
+          IMAGE: openquantumsafe/${{ matrix.image }}
+          ARCH_TAGS: ${{ matrix.tags }}
+        run: |
+          amend=()
+          for tag in $ARCH_TAGS; do amend+=(--amend "$IMAGE:$tag"); done
+          docker manifest create "$IMAGE:latest" "${amend[@]}"
+          docker manifest push "$IMAGE:latest"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,10 +29,14 @@ jobs:
 
       - name: Read images.yml
         id: list
+        # Assigned first so that a failure fails the step: inside `echo "x=$(…)"`
+        # the exit status would be echo's, and an empty value would reach fromJSON.
         run: |
+          images=$(./.github/scripts/list-images.sh --matrix)
+          multiarch=$(./.github/scripts/list-images.sh --multiarch)
           {
-            echo "images=$(./.github/scripts/list-images.sh --matrix)"
-            echo "multiarch=$(./.github/scripts/list-images.sh --multiarch)"
+            echo "images=$images"
+            echo "multiarch=$multiarch"
           } >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,7 @@
 name: Build and push Docker images
 
-# Publishes every image in images.yml to Docker Hub. Nothing is built until the
-# pre-build checks pass, and nothing is pushed until it has passed the
-# vulnerability scan in .github/workflows/build-image.yml, where the steps live.
+# Publishes every image in images.yml. Nothing is built until the pre-build
+# checks pass, nothing pushed until it passes the scan in build-image.yml.
 on:
   push:
     branches: 'main'
@@ -29,8 +28,8 @@ jobs:
 
       - name: Read images.yml
         id: list
-        # Assigned first so that a failure fails the step: inside `echo "x=$(…)"`
-        # the exit status would be echo's, and an empty value would reach fromJSON.
+        # Assigned first: inside `echo "x=$(…)"` a failure would be echo's,
+        # leaving fromJSON an empty string.
         run: |
           images=$(./.github/scripts/list-images.sh --matrix)
           multiarch=$(./.github/scripts/list-images.sh --multiarch)
@@ -50,14 +49,16 @@ jobs:
       tag: ${{ matrix.tag }}
       arch: ${{ matrix.arch }}
       runner: ${{ matrix.runner }}
-      push: true
+      # Only this repository has the credentials; a fork builds and scans only.
+      push: ${{ github.repository == 'open-quantum-safe/ci-containers' }}
     secrets:
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # The per-architecture tags are published above; for an image built for more
-  # than one architecture, :latest is the manifest spanning them.
+  # :latest is the manifest spanning the per-architecture tags published above.
   multiarch:
     name: Manifest for ${{ matrix.image }}
+    # Nothing was pushed on a fork, so there is nothing to span.
+    if: github.repository == 'open-quantum-safe/ci-containers'
     needs: [discover, publish]
     strategy:
       matrix: ${{ fromJSON(needs.discover.outputs.multiarch) }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,24 @@
+# hadolint configuration for the images CI builds and publishes.
+#
+# `ignored` rules are ones this project has deliberately decided against: these
+# are CI base images whose whole purpose is to provide current toolchains, so
+# the version-pinning rules work against them. Everything else stays enabled, so
+# a new class of warning fails the build (see .github/workflows/checks.yml).
+#
+# Findings that are real but not yet addressed or are potentially useful are demoted
+# to `info` rather than ignored, so they keep showing up in the lint output instead
+# of disappearing.  There should be a rationale recorded here for decisions made.
+
+failure-threshold: warning
+
+ignored:
+  - DL3007 # `FROM ubuntu:latest` | rationale: ci-ubuntu-latest tracks the newest Ubuntu by design.
+  - DL3008 # pin apt versions | rationale: would freeze the toolchains these images exist to provide.
+  - DL3013 # pin pip versions | rationale: as above.
+  - DL3016 # pin npm versions | rationale: as above.
+  - DL3018 # pin apk versions | rationale: as above.
+
+override:
+  info:
+    # pip cache left in the image | rationale: size debt, contrary to goals of PR#108
+    - DL3042

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 The **Open Quantum Safe (OQS) project** has the goal of developing and prototyping quantum-resistant cryptography. This repository contains Dockerfiles that establish the environments used for CI testing of the various OQS sub-projects.
 
+### Changing an image
+
+Every push to `main` republishes `:latest`, so the `LABEL version` in a Dockerfile is (currently) the only signal consumers get that what they pull has changed. **If you change anything in an image's build context, bump that image's `LABEL version`** to the next whole number; CI fails the pull request otherwise. Republishing under an already-released version could silently change what a downstream project builds against: anyone consuming the mutable `:latest` tag, rather than pinning the image by `@sha256:...` digest, picks the new image up without review.
+
+Before anything is built, [`Pre-build checks`](.github/workflows/checks.yml) lints the Dockerfiles with [hadolint](https://github.com/hadolint/hadolint) (accepted rules are recorded, with reasons, in [`.hadolint.yaml`](.hadolint.yaml)), checks those versions, and runs `shellcheck`, `actionlint` and [`zizmor`](https://docs.zizmor.sh) over the scripts and workflows. Each image is then built and scanned with [Trivy](https://trivy.dev); a fixable critical vulnerability stops it being pushed.
+
+It is recommended to run these tools locally before submitting a pull request, so you can fix any issues before CI runs.
+
+### Adding an image
+
+[`images.yml`](images.yml) contains the full set of this repository's images. The linting, version check, build, scan and push are all derived from it. **Adding a container is a new directory plus an entry in `images.yml`**. A directory holding a Dockerfile that is absent from `images.yml` is not built.
+
 ### License
 
 This repository is licensed under the MIT License; see [LICENSE.txt](https://github.com/open-quantum-safe/testing/blob/master/LICENSE.txt) for details.

--- a/images.yml
+++ b/images.yml
@@ -1,18 +1,13 @@
-# The images this repository builds, scans and publishes to Docker Hub.
+# The images this repository builds, scans and publishes to Docker Hub, and the
+# only place that set is written down: the build and publish matrices, the
+# linting and the version check all derive from it.
 #
-# This is the only place the image set is written down: the build and publish
-# matrices, the Dockerfile linting and the LABEL version check are all derived
-# from it, so adding or retiring an image is a change here and to its directory,
-# with no workflow to keep in step.
-#
-#   dir     directory holding the image's Dockerfile
+#   dir     directory holding the Dockerfile
 #   image   Docker Hub repository, without the openquantumsafe/ prefix
-#   arches  architectures to build, each natively on a runner of that
-#           architecture. A single architecture is published as :latest; several
-#           are published as :latest-<arch>, spanned by a :latest manifest.
+#   arches  architectures, each built natively. One is published as :latest,
+#           several as :latest-<arch> spanned by a :latest manifest.
 #
-# Directories with a Dockerfile that are absent from this list are not built:
-# they are the retired images kept for reference.
+# A directory with a Dockerfile and no entry here is retired, and is not built.
 
 images:
   - dir: alpine

--- a/images.yml
+++ b/images.yml
@@ -1,0 +1,32 @@
+# The images this repository builds, scans and publishes to Docker Hub.
+#
+# This is the only place the image set is written down: the build and publish
+# matrices, the Dockerfile linting and the LABEL version check are all derived
+# from it, so adding or retiring an image is a change here and to its directory,
+# with no workflow to keep in step.
+#
+#   dir     directory holding the image's Dockerfile
+#   image   Docker Hub repository, without the openquantumsafe/ prefix
+#   arches  architectures to build, each natively on a runner of that
+#           architecture. A single architecture is published as :latest; several
+#           are published as :latest-<arch>, spanned by a :latest manifest.
+#
+# Directories with a Dockerfile that are absent from this list are not built:
+# they are the retired images kept for reference.
+
+images:
+  - dir: alpine
+    image: ci-alpine-amd64
+    arches: [amd64]
+
+  - dir: ubuntu-focal
+    image: ci-ubuntu-focal
+    arches: [x86_64, arm64]
+
+  - dir: ubuntu-jammy
+    image: ci-ubuntu-jammy
+    arches: [x86_64, arm64]
+
+  - dir: ubuntu-latest
+    image: ci-ubuntu-latest
+    arches: [x86_64, arm64]

--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -1,9 +1,9 @@
 ARG ARCH
 FROM ubuntu:focal
-LABEL version="5"
+LABEL version="6"
 ARG ARCH
 
-RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
+RUN export DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update -qq && \
@@ -51,6 +51,12 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     npm -g install ajv ajv-cli && \
     pip3 install tabulate jinja2
 
+# WORKDIR cannot be made conditional, and this builds on amd64 only.
+# hadolint ignore=DL3003
 RUN if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x64" ] || [ "$ARCH" = "x86_64" ]; then cd / && git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
-RUN cd /root && wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 15 all
+
+WORKDIR /root
+RUN wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && ./llvm.sh 15 all
+WORKDIR /
+
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"

--- a/ubuntu-focal/Dockerfile
+++ b/ubuntu-focal/Dockerfile
@@ -51,7 +51,7 @@ RUN export DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     npm -g install ajv ajv-cli && \
     pip3 install tabulate jinja2
 
-# WORKDIR cannot be made conditional, and this builds on amd64 only.
+# WORKDIR cannot be conditional.
 # hadolint ignore=DL3003
 RUN if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x64" ] || [ "$ARCH" = "x86_64" ]; then cd / && git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version ; fi
 

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -50,9 +50,7 @@ RUN cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --versi
 WORKDIR /
 
 # Ubuntu names the JDK directory after the Debian architecture (amd64), not the
-# ARCH build-arg this image is passed (x86_64), so JAVA_HOME is resolved here
-# rather than interpolated. The javac check fails the build if the JDK moves,
-# instead of leaving a JAVA_HOME that silently points nowhere.
+# ARCH build-arg (x86_64), so resolve it here; javac asserts it exists.
 RUN ln -sfn "/usr/lib/jvm/java-1.11.0-openjdk-$(dpkg --print-architecture)" /usr/lib/jvm/java-11 && \
     [ -x /usr/lib/jvm/java-11/bin/javac ]
 ENV JAVA_HOME="/usr/lib/jvm/java-11"

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:jammy
-LABEL version="3"
+LABEL version="4"
 ARG ARCH
 
-RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
+RUN export DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update -qq && \
@@ -44,7 +44,11 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
                        yamllint && \
      pip3 install tabulate jinja2
 
-RUN cd / && git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git && cd doxygen && mkdir build && cd build && cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version 
+RUN git clone --depth 1 --branch Release_1_10_0 https://github.com/doxygen/doxygen.git /doxygen
+WORKDIR /doxygen/build
+RUN cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version
+WORKDIR /
+
 ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-${ARCH}"
 # Activate if we want to test specific OpenSSL3 versions:
 # RUN cd /root && git clone --depth 1 --branch openssl-3.0.7 https://github.com/openssl/openssl.git && cd openssl && LDFLAGS="-Wl,-rpath -Wl,/usr/local/openssl3/lib64"  ./config --prefix=/usr/local/openssl3 && make -j && make install

--- a/ubuntu-jammy/Dockerfile
+++ b/ubuntu-jammy/Dockerfile
@@ -49,6 +49,12 @@ WORKDIR /doxygen/build
 RUN cmake -G "Unix Makefiles" .. && make -j 4 && make install && doxygen --version
 WORKDIR /
 
-ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-${ARCH}"
+# Ubuntu names the JDK directory after the Debian architecture (amd64), not the
+# ARCH build-arg this image is passed (x86_64), so JAVA_HOME is resolved here
+# rather than interpolated. The javac check fails the build if the JDK moves,
+# instead of leaving a JAVA_HOME that silently points nowhere.
+RUN ln -sfn "/usr/lib/jvm/java-1.11.0-openjdk-$(dpkg --print-architecture)" /usr/lib/jvm/java-11 && \
+    [ -x /usr/lib/jvm/java-11/bin/javac ]
+ENV JAVA_HOME="/usr/lib/jvm/java-11"
 # Activate if we want to test specific OpenSSL3 versions:
 # RUN cd /root && git clone --depth 1 --branch openssl-3.0.7 https://github.com/openssl/openssl.git && cd openssl && LDFLAGS="-Wl,-rpath -Wl,/usr/local/openssl3/lib64"  ./config --prefix=/usr/local/openssl3 && make -j && make install

--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -108,8 +108,7 @@ COPY valgrind-try-patch-20250805.txt /tmp/
 COPY valgrind-varlat-patch-20250805.txt /tmp/
 COPY valgrind-varlat-sup-block.txt /tmp/
 
-# WORKDIR would split this across layers, leaving the source tree and the build
-# objects in the image even though the rm at the end deletes them.
+# WORKDIR would split this across layers, keeping the source tree the rm drops.
 # hadolint ignore=DL3003
 RUN git clone git://sourceware.org/git/valgrind.git /tmp/valgrind_varlat_src && \
     cd /tmp/valgrind_varlat_src && \

--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest as base
-LABEL version="3"
+LABEL version="4"
 
 # actionlint - for GitHub workflow file validation
 # (version pinned to commit hash of v1.7.1)
@@ -37,7 +37,7 @@ COPY --from=build /usr/local/bin/actionlint /usr/local/bin/actionlint
 ARG ARCH
 ENV ARCH=${ARCH}
 
-RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
+RUN export DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update -qq && \
@@ -110,6 +110,9 @@ COPY valgrind-try-patch-20250805.txt /tmp/
 COPY valgrind-varlat-patch-20250805.txt /tmp/
 COPY valgrind-varlat-sup-block.txt /tmp/
 
+# WORKDIR would split this across layers, leaving the source tree and the build
+# objects in the image even though the rm at the end deletes them.
+# hadolint ignore=DL3003
 RUN git clone git://sourceware.org/git/valgrind.git /tmp/valgrind_varlat_src && \
     cd /tmp/valgrind_varlat_src && \
     git checkout 112f1080b7c21e37dfce0a2e589d0dc7aa115afa && \

--- a/ubuntu-latest/Dockerfile
+++ b/ubuntu-latest/Dockerfile
@@ -1,6 +1,3 @@
-FROM ubuntu:latest as base
-LABEL version="4"
-
 # actionlint - for GitHub workflow file validation
 # (version pinned to commit hash of v1.7.1)
 FROM golang:1.23 as build
@@ -31,6 +28,7 @@ RUN opam init --yes --auto-setup && \
 
 # copy built binary from build stage to final image
 FROM ubuntu:latest
+LABEL version="4"
 WORKDIR /root
 COPY --from=build /usr/local/bin/actionlint /usr/local/bin/actionlint
 


### PR DESCRIPTION
Introduce `images.yml` as the single source of truth for the image set: the build and publish matrices, Dockerfile linting and the version check are all derived from it via `.github/scripts/list-images.sh`.

Move the build/scan/push steps into a reusable `build-image.yml` workflow, called by both the pull-request build and the main-branch publish. This allows images to be scanned with Trivy between build and push, so a fixable critical vulnerability is never published, and the multiarch manifest is assembled from the per-architecture tags.

Add a "Pre-build checks" workflow (also gating publication) that:
- lints Dockerfiles with **hadolint**, configured in `.hadolint.yaml` with rationales for each accepted/ignored rule
- verifies `images.yml` matches the repository layout
- enforces that a changed build context bumps its LABEL version past the released one (check-image-versions.sh)
- runs `shellcheck`, `actionlint` and `zizmor` over scripts and workflows

Harden workflows: least-privilege permissions, no persisted credentials, and actions pinned to commit SHAs (matching merged PR on `oqs-provider`.

Also fix hadolint findings in the Ubuntu Dockerfiles (exported DEBIAN_FRONTEND/TZ, WORKDIR instead of cd) and bump their LABEL versions accordingly.

Document the `image-change` and `image-addition` process in the README.